### PR TITLE
fix: resolve eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,15 +1,5 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-import js from "@eslint/js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+import coreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
   {
@@ -22,9 +12,8 @@ const eslintConfig = [
     ],
   },
 
-  ...compat.config({
-    extends: ["next/core-web-vitals", "next/typescript"],
-  }),
+  ...coreWebVitals,
+  ...nextTypescript,
 
   {
     rules: {


### PR DESCRIPTION
This pull request updates the ESLint configuration to directly use the official Next.js ESLint config packages instead of the previous compatibility layer. This streamlines the configuration and ensures better alignment with Next.js best practices.

**ESLint configuration modernization:**

* Replaced usage of `FlatCompat` and manual compatibility setup with direct imports of `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript` in `eslint.config.mjs`, removing unnecessary code and dependencies.
* Updated the `eslintConfig` array to spread the configurations from `coreWebVitals` and `nextTypescript` directly, instead of using the compatibility layer and `extends`.