### PR TITLE
feat: add auth functionalities and toast component

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -11,9 +11,15 @@ import gsap from "gsap";
 import { loginSchema, type LoginSchema } from "@/shared/schemas/login.schema";
 import { Field } from "@/shared/components/ui/Field";
 import { Button, Divider, Input } from "@/shared/components/ui";
+import { useToast } from "@/lib/hooks/useToast";
+import { useRouter } from "next/navigation";
+import { useConvexAuth } from "convex/react";
 
 export default function LoginPage() {
   const { signIn } = useAuthActions();
+  const { toast } = useToast();
+  const { isAuthenticated } = useConvexAuth();
+  const router = useRouter();
 
   const [showPassword, setShowPassword] = useState(false);
 
@@ -31,6 +37,13 @@ export default function LoginPage() {
   } = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),
   });
+
+  // INFO: Auto login redirect if already authenticated
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push("/dashboard");
+    }
+  }, [isAuthenticated, router]);
 
   useEffect(() => {
     const ctx = gsap.context(() => {
@@ -67,8 +80,18 @@ export default function LoginPage() {
   const onSubmit = async (data: LoginSchema) => {
     try {
       await signIn("password", data);
+
+      toast.success({
+        title: "Login successful",
+        description: "Welcome back!",
+      });
+      router.push("/dashboard");
     } catch (error) {
       console.error("Login failed:", error);
+      toast.error({
+        title: "Login failed",
+        description: "Check your credentials or try again later",
+      });
     }
   };
 

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -13,9 +13,13 @@ import {
   RegisterSchema,
 } from "@/shared/schemas/register.schema";
 import { useAuthActions } from "@convex-dev/auth/react";
+import { useToast } from "@/lib/hooks/useToast";
+import { useRouter } from "next/navigation";
 
 export default function RegisterPage() {
   const { signIn } = useAuthActions();
+  const { toast } = useToast();
+  const router = useRouter();
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -70,8 +74,11 @@ export default function RegisterPage() {
   const onSubmit = async (data: RegisterSchema) => {
     try {
       await signIn("password", data);
+      toast.success("Account created successfully! You are now signed in.");
+      router.push("/dashboard");
     } catch (error) {
       console.error("Registration error:", error);
+      toast.error("Failed to create account. Please try again.");
     }
   };
 

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <></>;
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,0 +1,9 @@
+import AuthGuard from "@/shared/components/auth-guard";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthGuard>{children}</AuthGuard>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono, Host_Grotesk } from "next/font/google";
 import { ReactLenis } from "lenis/react";
 import "./globals.css";
 import { ConvexClientProvider } from "@/shared/components/providers/convex-client-provider";
+import StoreProvider from "@/shared/components/providers/store-provider";
+import { Toast } from "@/shared/components/ui";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -36,8 +38,11 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col">
         <ConvexClientProvider>
-          <ReactLenis root />
-          {children}
+          <StoreProvider>
+            <ReactLenis root />
+            {children}
+            <Toast />
+          </StoreProvider>
         </ConvexClientProvider>
       </body>
     </html>

--- a/lib/hooks/useToast.ts
+++ b/lib/hooks/useToast.ts
@@ -1,0 +1,56 @@
+import { addToast, removeToast } from "@/lib/store/slices/config/configSlice";
+import type { ToastVariant } from "@/lib/types/toast.types";
+import { AppDispatch, store } from "@/lib/store/store";
+import { useDispatch } from "react-redux";
+
+export type ToastOptions = {
+  title: string;
+  description?: string;
+  duration?: number;
+};
+
+function generateId() {
+  return Math.random().toString(36).slice(2);
+}
+
+function buildToast(variant: ToastVariant, options: ToastOptions | string) {
+  const resolved = typeof options === "string" ? { title: options } : options;
+  return { id: generateId(), variant, ...resolved };
+}
+
+export const toast = {
+  default: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("default", options))),
+  success: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("success", options))),
+  danger: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("danger", options))),
+  error: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("danger", options))),
+  warning: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("warning", options))),
+  info: (options: ToastOptions | string) =>
+    store.dispatch(addToast(buildToast("info", options))),
+};
+
+export function useToast() {
+  const dispatch = useDispatch<AppDispatch>();
+
+  function createMethod(variant: ToastVariant) {
+    return (options: ToastOptions | string) => {
+      dispatch(addToast(buildToast(variant, options)));
+    };
+  }
+
+  return {
+    toast: {
+      default: createMethod("default"),
+      success: createMethod("success"),
+      danger: createMethod("danger"),
+      error: createMethod("danger"),
+      warning: createMethod("warning"),
+      info: createMethod("info"),
+    },
+    remove: (id: string) => dispatch(removeToast(id)),
+  };
+}

--- a/lib/store/slices/config/configSlice.ts
+++ b/lib/store/slices/config/configSlice.ts
@@ -1,0 +1,70 @@
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type { Toast } from "@/lib/types/toast.types";
+
+export type Language = "en" | "es" | "fr" | "de" | "pt";
+
+export type Theme = "dark" | "light" | "system";
+
+export type NotificationSettings = {
+  sound: boolean;
+  push: boolean;
+  email: boolean;
+};
+
+type ConfigState = {
+  toasts: Toast[];
+  language: Language;
+  theme: Theme;
+  notifications: NotificationSettings;
+};
+
+const initialState: ConfigState = {
+  toasts: [],
+  language: "en",
+  theme: "dark",
+  notifications: {
+    sound: true,
+    push: true,
+    email: false,
+  },
+};
+
+export const configSlice = createSlice({
+  name: "config",
+  initialState,
+  reducers: {
+    addToast: (state, action: PayloadAction<Toast>) => {
+      state.toasts.push(action.payload);
+    },
+    removeToast: (state, action: PayloadAction<string>) => {
+      const index = state.toasts.findIndex((t) => t.id === action.payload);
+      if (index !== -1) state.toasts.splice(index, 1);
+    },
+
+    setLanguage: (state, action: PayloadAction<Language>) => {
+      state.language = action.payload;
+    },
+
+    setTheme: (state, action: PayloadAction<Theme>) => {
+      state.theme = action.payload;
+    },
+
+    setNotifications: (
+      state,
+      action: PayloadAction<Partial<NotificationSettings>>,
+    ) => {
+      Object.assign(state.notifications, action.payload);
+    },
+  },
+});
+
+export const {
+  addToast,
+  removeToast,
+  setLanguage,
+  setTheme,
+  setNotifications,
+} = configSlice.actions;
+
+export default configSlice.reducer;

--- a/lib/store/slices/counter/counterSlice.ts
+++ b/lib/store/slices/counter/counterSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+interface CounterState {
+  count: number;
+}
+
+const initialState: CounterState = {
+  count: 0,
+};
+
+const counterSlice = createSlice({
+  name: "counter",
+  initialState,
+  reducers: {
+    increment: (state) => {
+      state.count += 1;
+    },
+    decrement: (state) => {
+      state.count -= 1;
+    },
+  },
+});
+
+export const { increment, decrement } = counterSlice.actions;
+export default counterSlice.reducer;

--- a/lib/store/store.ts
+++ b/lib/store/store.ts
@@ -7,9 +7,8 @@ import {
 import counterReducer from "./slices/counter/counterSlice";
 import configReducer from "./slices/config/configSlice";
 
-import { persistReducer } from "redux-persist";
+import { persistReducer, persistStore } from "redux-persist";
 import storage from "redux-persist/lib/storage";
-import persistStore from "redux-persist/es/persistStore";
 
 const rootReducer = combineReducers({
   counter: counterReducer,

--- a/lib/store/store.ts
+++ b/lib/store/store.ts
@@ -1,0 +1,44 @@
+import {
+  Action,
+  combineReducers,
+  configureStore,
+  ThunkAction,
+} from "@reduxjs/toolkit";
+import counterReducer from "./slices/counter/counterSlice";
+import configReducer from "./slices/config/configSlice";
+
+import { persistReducer } from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import persistStore from "redux-persist/es/persistStore";
+
+const rootReducer = combineReducers({
+  counter: counterReducer,
+  config: configReducer,
+});
+
+const persistConfig = {
+  key: "root",
+  storage,
+  whitelist: ["counter"],
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
+});
+
+export const persistor = persistStore(store);
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export type AppThunk<ReturnType = void> = ThunkAction<
+  ReturnType,
+  RootState,
+  unknown,
+  Action<string>
+>;

--- a/lib/types/toast.types.ts
+++ b/lib/types/toast.types.ts
@@ -1,0 +1,14 @@
+export type ToastVariant =
+  | "default"
+  | "success"
+  | "danger"
+  | "warning"
+  | "info";
+
+export type Toast = {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@lexical/rich-text": "^0.42.0",
     "@lexical/selection": "^0.42.0",
     "@lexical/utils": "^0.42.0",
+    "@reduxjs/toolkit": "^2.11.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "convex": "^1.34.1",
     "gsap": "^3.14.2",
@@ -31,6 +32,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.0",
+    "react-redux": "^9.2.0",
+    "redux-persist": "^6.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@lexical/utils':
         specifier: ^0.42.0
         version: 0.42.0
+      '@reduxjs/toolkit':
+        specifier: ^2.11.2
+        version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -68,6 +71,12 @@ importers:
       react-hook-form:
         specifier: ^7.72.0
         version: 7.72.0(react@19.2.4)
+      react-redux:
+        specifier: ^9.2.0
+        version: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      redux-persist:
+        specifier: ^6.0.0
+        version: 6.0.0(react@19.2.4)(redux@5.0.1)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -896,6 +905,17 @@ packages:
   '@preact/signals-core@1.14.0':
     resolution: {integrity: sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1154,6 +1174,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -2029,6 +2052,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2617,9 +2643,38 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  redux-persist@6.0.0:
+    resolution: {integrity: sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==}
+    peerDependencies:
+      react: '>=16'
+      redux: '>4.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2632,6 +2687,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2963,6 +3021,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-tsconfig-paths@6.1.1:
     resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
@@ -3869,6 +3932,18 @@ snapshots:
 
   '@preact/signals-core@1.14.0': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
@@ -4056,6 +4131,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5082,6 +5159,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5644,7 +5723,28 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react@19.2.4: {}
+
+  redux-persist@6.0.0(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+    optionalDependencies:
+      react: 19.2.4
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5667,6 +5767,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -6102,6 +6204,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:

--- a/shared/components/auth-guard.tsx
+++ b/shared/components/auth-guard.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useConvexAuth } from "convex/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function AuthGuard({ children }: { children: React.ReactNode }) {
+  const { isLoading, isAuthenticated } = useConvexAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push("/login");
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading || !isAuthenticated) {
+    return (
+      <div className="flex items-center justify-center h-dvh">
+        <p className="text-zinc-500">Loading...</p>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/shared/components/auth-guard.tsx
+++ b/shared/components/auth-guard.tsx
@@ -17,7 +17,7 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   if (isLoading || !isAuthenticated) {
     return (
       <div className="flex items-center justify-center h-dvh">
-        <p className="text-zinc-500">Loading...</p>
+        <p className="text-zinc-500">Redirecting...</p>
       </div>
     );
   }

--- a/shared/components/providers/store-provider.tsx
+++ b/shared/components/providers/store-provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { Provider } from "react-redux";
+import { store } from "@/lib/store/store";
+
+export default function StoreProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/shared/components/ui/index.ts
+++ b/shared/components/ui/index.ts
@@ -8,3 +8,4 @@ export { Divider } from "./divider";
 export { Avatar } from "./avatar";
 export { Card } from "./card";
 export { Spinner } from "./spinner";
+export { Toast } from "./toast";

--- a/shared/components/ui/toast/Toast.tsx
+++ b/shared/components/ui/toast/Toast.tsx
@@ -118,7 +118,7 @@ function ToastItem({ toast }: { toast: Toast }) {
       clearTimeout(exitTimer);
       tl.kill();
     };
-  }, [duration, handleRemove]);
+  }, [duration]);
 
   return (
     <div
@@ -150,6 +150,7 @@ function ToastItem({ toast }: { toast: Toast }) {
       <button
         type="button"
         onClick={handleRemove}
+        aria-label="Close Notification"
         className="shrink-0 mt-0.5 text-zinc-600 hover:text-zinc-400 transition-colors duration-150 cursor-pointer"
       >
         <X size={14} />

--- a/shared/components/ui/toast/Toast.tsx
+++ b/shared/components/ui/toast/Toast.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  X,
+  CheckCircle2,
+  AlertCircle,
+  AlertTriangle,
+  Info,
+  Bell,
+} from "lucide-react";
+import gsap from "gsap";
+
+import { removeToast } from "@/lib/store/slices/config/configSlice";
+import type { Toast, ToastVariant } from "@/lib/types/toast.types";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/lib/store/store";
+
+const DEFAULT_DURATION = 4000;
+
+const variantConfig: Record<
+  ToastVariant,
+  {
+    icon: React.ReactNode;
+    bar: string;
+    container: string;
+    title: string;
+    description: string;
+  }
+> = {
+  default: {
+    icon: <Bell size={15} />,
+    bar: "bg-zinc-500",
+    container: "bg-zinc-900 border-zinc-700/80 text-zinc-400",
+    title: "text-zinc-200",
+    description: "text-zinc-500",
+  },
+  success: {
+    icon: <CheckCircle2 size={15} />,
+    bar: "bg-emerald-500",
+    container: "bg-zinc-900 border-emerald-900/60 text-emerald-400",
+    title: "text-zinc-200",
+    description: "text-zinc-500",
+  },
+  danger: {
+    icon: <AlertCircle size={15} />,
+    bar: "bg-red-500",
+    container: "bg-zinc-900 border-red-900/60 text-red-400",
+    title: "text-zinc-200",
+    description: "text-zinc-500",
+  },
+  warning: {
+    icon: <AlertTriangle size={15} />,
+    bar: "bg-amber-500",
+    container: "bg-zinc-900 border-amber-900/60 text-amber-400",
+    title: "text-zinc-200",
+    description: "text-zinc-500",
+  },
+  info: {
+    icon: <Info size={15} />,
+    bar: "bg-blue-500",
+    container: "bg-zinc-900 border-blue-900/60 text-blue-400",
+    title: "text-zinc-200",
+    description: "text-zinc-500",
+  },
+};
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const dispatch = useDispatch<AppDispatch>();
+  const ref = useRef<HTMLDivElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const variant = toast.variant ?? "default";
+  const config = variantConfig[variant];
+  const duration = toast.duration ?? DEFAULT_DURATION;
+
+  const handleRemove = () => {
+    const el = ref.current;
+    if (!el) return;
+    gsap.to(el, {
+      x: 40,
+      opacity: 0,
+      filter: "blur(4px)",
+      duration: 0.25,
+      ease: "power2.in",
+      onComplete: () => {
+        dispatch(removeToast(toast.id));
+      },
+    });
+  };
+
+  useEffect(() => {
+    const el = ref.current;
+    const bar = barRef.current;
+    if (!el || !bar) return;
+
+    const tl = gsap.timeline();
+
+    tl.fromTo(
+      el,
+      { x: 40, opacity: 0, filter: "blur(4px)" },
+      {
+        x: 0,
+        opacity: 1,
+        filter: "blur(0px)",
+        duration: 0.45,
+        ease: "power3.out",
+      },
+    ).fromTo(
+      bar,
+      { scaleX: 1 },
+      { scaleX: 0, duration: duration / 1000, ease: "none" },
+      "-=0.1",
+    );
+
+    const exitTimer = setTimeout(handleRemove, duration);
+
+    return () => {
+      clearTimeout(exitTimer);
+      tl.kill();
+    };
+  }, [duration, handleRemove]);
+
+  return (
+    <div
+      ref={ref}
+      className={`
+        relative flex items-start gap-3 w-80 rounded-2xl border px-4 py-3.5
+        shadow-xl shadow-black/40 overflow-hidden
+        ${config.container}
+      `}
+    >
+      <div
+        ref={barRef}
+        className={`absolute bottom-0 left-0 h-0.5 w-full origin-left ${config.bar}`}
+      />
+
+      <span className="shrink-0 mt-0.5">{config.icon}</span>
+
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-medium leading-snug ${config.title}`}>
+          {toast.title}
+        </p>
+        {toast.description && (
+          <p className={`text-xs mt-0.5 leading-relaxed ${config.description}`}>
+            {toast.description}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={handleRemove}
+        className="shrink-0 mt-0.5 text-zinc-600 hover:text-zinc-400 transition-colors duration-150 cursor-pointer"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+export function Toast() {
+  const configState = useSelector((state: RootState) => state.config);
+
+  const toasts = configState.toasts;
+
+  return (
+    <div className="fixed bottom-6 right-6 z-100 flex flex-col gap-2.5 items-end">
+      {toasts.map((t) => (
+        <ToastItem key={t.id} toast={t} />
+      ))}
+    </div>
+  );
+}

--- a/shared/components/ui/toast/index.ts
+++ b/shared/components/ui/toast/index.ts
@@ -1,0 +1,1 @@
+export { Toast } from "./Toast";


### PR DESCRIPTION
This pull request introduces a global toast notification system using Redux Toolkit and Redux Persist, and integrates it into the authentication flow. It also sets up basic Redux store infrastructure, adds a dashboard page guarded by authentication, and updates the app layout to support toasts and global state. The most important changes are grouped below:

**Toast Notification System:**

* Added a reusable toast notification system with variants (success, error, warning, etc.), including Redux slice (`configSlice`), types, and a React hook (`useToast`) for dispatching toasts. Toasts are now shown on login, registration, and error events. 
* Integrated the `Toast` UI component and provider into the root layout so toasts are globally available. 

**Redux Store Infrastructure:**

* Set up Redux Toolkit store with slices for configuration (toasts, theme, language, notifications) and a sample counter, using Redux Persist to persist the counter state. 
* Added required dependencies for Redux, Redux Toolkit, Redux Persist, and React-Redux to `package.json` and `pnpm-lock.yaml`. 

**Authentication Flow Enhancements:**

* Added automatic redirect to `/dashboard` if the user is already authenticated on the login page.
* Added toast notifications and redirect to `/dashboard` on successful login and registration, and error toasts on failure.

**Dashboard and Route Protection:**

* Added a placeholder `DashboardPage` and an `AuthGuard`-wrapped dashboard layout to protect dashboard routes for authenticated users only. 

**Other Minor Changes:**

* Imported and initialized the Redux store provider in the app layout to enable global state management. 

These changes establish a scalable foundation for global state management and user feedback, and improve the authentication experience.