### PR TITLE
feat: add single page note with markdown render

### DIFF
--- a/app/(dashboard)/dashboard/notes/[slug]/NotePage.tsx
+++ b/app/(dashboard)/dashboard/notes/[slug]/NotePage.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { api } from "@/convex/_generated/api";
+import { Loader } from "@/shared/components/ui";
+import {
+  editorTheme,
+  SaveStatus,
+} from "@/shared/components/ui/note/NoteEditor";
+import {
+  InitialConfigType,
+  LexicalComposer,
+} from "@lexical/react/LexicalComposer";
+import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
+import { useMutation, useQuery } from "convex/react";
+
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode } from "@lexical/code";
+import { LinkNode } from "@lexical/link";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { useEffect, useRef, useState } from "react";
+import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { TRANSFORMERS } from "@lexical/markdown";
+import { ParagraphNode } from "lexical";
+
+interface Props {
+  slug: string;
+}
+
+export default function NotePage({ slug }: Props) {
+  const note = useQuery(api.myFunctions.getNote, { slug });
+
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [titleDraft, setTitleDraft] = useState(note?.title || "");
+
+  const updateNote = useMutation(api.myFunctions.updateNote);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  if (!note) {
+    return (
+      <div className="flex items-center justify-center h-dvh">
+        <Loader variant="circle" size="lg" />
+      </div>
+    );
+  }
+
+  const editorConfig: InitialConfigType = {
+    namespace: "inkwell-note-viewer",
+    theme: editorTheme,
+    onError: (error: Error) => console.error(error),
+    editorState: note.content || "",
+    nodes: [
+      ParagraphNode,
+      HorizontalRuleNode,
+      CodeNode,
+      HeadingNode,
+      LinkNode,
+      ListNode,
+      ListItemNode,
+      QuoteNode,
+    ],
+  };
+
+  const handleUpdateNote = async (json: string) => {
+    if (!titleDraft.trim()) return;
+    try {
+      setSaveStatus("saving");
+
+      await updateNote({
+        id: note._id,
+        title: titleDraft,
+        content: json,
+      });
+
+      setSaveStatus("saved");
+    } catch (error) {
+      console.error("Failed to save note:", error);
+    }
+  };
+
+  return (
+    <>
+      <LexicalComposer initialConfig={editorConfig}>
+        <div className="w-full relative h-dvh overflow-y-auto">
+          <span className="fixed text-zinc-500 select-none right-4 top-4">
+            {saveStatus}
+          </span>
+          <textarea
+            value={titleDraft}
+            onChange={(e) => setTitleDraft(e.target.value)}
+            placeholder="Untitled"
+            className="w-full z-10 !text-white min-h-auto outline-none resize-none overflow-y-hidden overflow-x-auto max-h-40 text-nowrap text-3xl font-semibold tracking-tight placeholder:text-zinc-500 leading-tight"
+          />
+          <RichTextPlugin
+            contentEditable={<ContentEditable className="viewer" />}
+            placeholder={null}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+
+          <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+          <OnChangePlugin
+            onChange={(editorState) => {
+              const json = JSON.stringify(editorState.toJSON());
+
+              if (timerRef.current) {
+                clearTimeout(timerRef.current);
+              }
+
+              timerRef.current = setTimeout(() => {
+                handleUpdateNote(json);
+              }, 3000);
+            }}
+          />
+        </div>
+      </LexicalComposer>
+    </>
+  );
+}

--- a/app/(dashboard)/dashboard/notes/[slug]/page.tsx
+++ b/app/(dashboard)/dashboard/notes/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import NotePage from "./NotePage";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return <NotePage slug={slug} />;
+}

--- a/app/(dashboard)/dashboard/notes/page.tsx
+++ b/app/(dashboard)/dashboard/notes/page.tsx
@@ -22,7 +22,7 @@ export default function NotesPage() {
   const [search, setSearch] = useState("");
   const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
 
-  const [draftTitle, setDraftTitle] = useState("Untitled");
+  const [draftTitle, setDraftTitle] = useState("");
   const [draftContent, setDraftContent] = useState("");
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
 
@@ -53,7 +53,6 @@ export default function NotesPage() {
 
     try {
       setSaveStatus("saving");
-      console.log("Title:", title, "Content (JSON):", draftContent);
       await createNote({
         title,
         content: draftContent,

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,3 +28,23 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+::-webkit-scrollbar {
+  background-color: #111111;
+  width: 6px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #000000;
+  border-radius: 10px;
+  box-shadow: 0 0 5px #000000;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #e7d944;
+}
+
+::-webkit-scrollbar-track {
+  background: #111111;
+  border-radius: 10px;
+}

--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,0 +1,35 @@
+import { createHeadlessEditor } from "@lexical/headless";
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode } from "@lexical/code";
+import { LinkNode } from "@lexical/link";
+import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown";
+
+export const jsonToMarkdown = (jsonContent: string) => {
+  const editor = createHeadlessEditor({
+    nodes: [
+      HorizontalRuleNode,
+      CodeNode,
+      HeadingNode,
+      LinkNode,
+      ListNode,
+      ListItemNode,
+      QuoteNode,
+    ],
+    onError: (error) => console.error(error),
+  });
+  try {
+    const editorState = editor.parseEditorState(jsonContent);
+
+    let markdown = "";
+    editorState.read(() => {
+      markdown = $convertToMarkdownString(TRANSFORMERS);
+    });
+
+    return markdown;
+  } catch (error) {
+    console.error("Failed to parse editor state:", error);
+    throw error;
+  }
+};

--- a/convex/myFunctions.ts
+++ b/convex/myFunctions.ts
@@ -34,6 +34,31 @@ export const getNotes = query({
   },
 });
 
+export const getNote = query({
+  args: {
+    slug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { slug } = args;
+    const userId = await getAuthUserId(ctx);
+
+    if (!userId) {
+      throw new Error("Not authenticated");
+    }
+
+    const note = await ctx.db
+      .query("notes")
+      .filter((q) => q.eq(q.field("slug"), slug))
+      .first();
+
+    if (!note) {
+      throw new Error("Note not found or not authorized");
+    }
+
+    return note;
+  },
+});
+
 export const addNote = mutation({
   args: {
     title: v.string(),
@@ -56,7 +81,7 @@ export const addNote = mutation({
     const note = {
       authorId: userId,
       title,
-      slug: `${title.toLowerCase().replace(/\s+/g, "-").substring(0, 5)}`,
+      slug: `${title.toLowerCase().replace(/\s+/g, "-")}`,
       preview,
       content,
       isDeleted: false,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@convex-dev/auth": "^0.0.91",
     "@hookform/resolvers": "^5.2.2",
     "@lexical/code": "0.43.0",
+    "@lexical/headless": "^0.43.0",
     "@lexical/history": "0.43.0",
     "@lexical/link": "0.43.0",
     "@lexical/list": "0.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@lexical/code':
         specifier: 0.43.0
         version: 0.43.0
+      '@lexical/headless':
+        specifier: ^0.43.0
+        version: 0.43.0
       '@lexical/history':
         specifier: 0.43.0
         version: 0.43.0
@@ -138,7 +141,7 @@ importers:
         version: 6.1.1(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3))
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@types/node@20.19.37)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -752,6 +755,9 @@ packages:
   '@lexical/hashtag@0.43.0':
     resolution: {integrity: sha512-oCKjY8/jkxJuu8iBnNX0WSLA6ZIYTn+v3NLpJxDqnAFZJCnJ2i/nM8GKzPMzHCDzJVNxbQB08fOptdXf8eN0Fg==}
 
+  '@lexical/headless@0.43.0':
+    resolution: {integrity: sha512-3qa+9fi6qawlCJkIV5D7hxsAbkhgeWwzwvpPqK02baNzDx5w+8n5WZ/W52G7yf8Binc3cocxAJ69nNYce23rbQ==}
+
   '@lexical/history@0.43.0':
     resolution: {integrity: sha512-SdrH3xgtUcolVRLihbQwiANQIiwSLdkKBon9oSsZNNnzVgEb7DUQUtJQGf33oW8HHWObIuWkh72W0fN1dZixOw==}
 
@@ -1167,6 +1173,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -1687,6 +1699,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -1991,6 +2007,10 @@ packages:
 
   gsap@3.14.2:
     resolution: {integrity: sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA==}
+
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3068,6 +3088,10 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -3112,6 +3136,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3706,6 +3742,14 @@ snapshots:
       '@lexical/utils': 0.43.0
       lexical: 0.43.0
 
+  '@lexical/headless@0.43.0':
+    dependencies:
+      happy-dom: 20.8.9
+      lexical: 0.43.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@lexical/history@0.43.0':
     dependencies:
       '@lexical/extension': 0.43.0
@@ -4087,6 +4131,12 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4600,6 +4650,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   es-abstract@1.24.1:
@@ -5072,6 +5124,18 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   gsap@3.14.2: {}
+
+  happy-dom@20.8.9:
+    dependencies:
+      '@types/node': 20.19.37
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-bigints@1.1.0: {}
 
@@ -6161,7 +6225,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@20.19.37)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@20.19.37)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -6185,6 +6249,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37
+      happy-dom: 20.8.9
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
@@ -6194,6 +6259,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 
@@ -6264,6 +6331,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.18.0: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/shared/components/ui/note/NoteDrawer.tsx
+++ b/shared/components/ui/note/NoteDrawer.tsx
@@ -9,6 +9,21 @@ import { Note } from "./NoteCard";
 import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useToast } from "@/lib/hooks/useToast";
+import {
+  InitialConfigType,
+  LexicalComposer,
+} from "@lexical/react/LexicalComposer";
+import { editorTheme } from "./NoteEditor";
+
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode } from "@lexical/code";
+import { LinkNode } from "@lexical/link";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { ParagraphNode } from "lexical";
 
 type NoteDrawerProps = {
   note: Note | null;
@@ -73,72 +88,89 @@ export function NoteDrawer({
     }
   };
 
+  const editorConfig: InitialConfigType = {
+    namespace: "inkwell-note-editor",
+    theme: editorTheme,
+    onError: (error: Error) => console.error(error),
+    editorState: note.content,
+    nodes: [
+      ParagraphNode,
+      HorizontalRuleNode,
+      CodeNode,
+      HeadingNode,
+      LinkNode,
+      ListNode,
+      ListItemNode,
+      QuoteNode,
+    ],
+  };
+
   return (
-    <Drawer
-      open={open}
-      onClose={onClose}
-      title={note.title || "Untitled"}
-      onExpand={() => router.push(`/notes/${note._id}`)}
-    >
-      <div className="flex flex-col h-full">
-        <div
-          className={`h-32 bg-gradient-to-br from-zinc-800 to-zinc-900 flex items-end p-5 relative`}
-        >
-          <div className="absolute top-4 right-4">
-            <Dropdown
-              trigger={
-                <button
-                  type="button"
-                  className="w-7 h-7 rounded-lg bg-zinc-800/80 border border-zinc-700 flex items-center justify-center text-zinc-400 hover:text-white transition-colors cursor-pointer"
-                >
-                  <MoreHorizontal size={14} />
-                </button>
-              }
-              items={menuItems.map((i) => ({
-                id: i.id,
-                label: i.label,
-                separator: i.separator,
-                variant: i.variant,
-              }))}
-              onSelect={(id) => {
-                const item = menuItems.find((m) => m.id === id);
-                item?.onClick();
-              }}
-              align="right"
-              width={180}
+    <LexicalComposer initialConfig={editorConfig}>
+      <Drawer
+        open={open}
+        onClose={onClose}
+        title={note.title || "Untitled"}
+        onExpand={() => router.push(`/dashboard/notes/${note.slug}`)}
+      >
+        <div className="flex flex-col h-full">
+          <div
+            className={`h-32 bg-gradient-to-br from-zinc-800 to-zinc-900 flex items-end p-5 relative`}
+          >
+            <div className="absolute top-4 right-4">
+              <Dropdown
+                trigger={
+                  <button
+                    type="button"
+                    className="w-7 h-7 rounded-lg bg-zinc-800/80 border border-zinc-700 flex items-center justify-center text-zinc-400 hover:text-white transition-colors cursor-pointer"
+                  >
+                    <MoreHorizontal size={14} />
+                  </button>
+                }
+                items={menuItems.map((i) => ({
+                  id: i.id,
+                  label: i.label,
+                  separator: i.separator,
+                  variant: i.variant,
+                }))}
+                onSelect={(id) => {
+                  const item = menuItems.find((m) => m.id === id);
+                  item?.onClick();
+                }}
+                align="right"
+                width={180}
+              />
+            </div>
+          </div>
+
+          <div className="px-5 py-4 border-b border-zinc-800 space-y-3">
+            <h2 className="text-white text-lg font-medium tracking-tight">
+              {note.title || "Untitled"}
+            </h2>
+
+            <div className="flex flex-wrap gap-3">
+              {note.updatedAt && (
+                <div className="flex items-center gap-1.5 text-[11px] text-zinc-600">
+                  <Calendar size={11} />
+                  {new Date(note.updatedAt).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex-1 px-5 py-4 overflow-y-auto">
+            <RichTextPlugin
+              contentEditable={<ContentEditable className="viewer-input" />}
+              placeholder={null}
+              ErrorBoundary={LexicalErrorBoundary}
             />
           </div>
         </div>
-
-        <div className="px-5 py-4 border-b border-zinc-800 space-y-3">
-          <h2 className="text-white text-lg font-medium tracking-tight">
-            {note.title || "Untitled"}
-          </h2>
-
-          <div className="flex flex-wrap gap-3">
-            {note.updatedAt && (
-              <div className="flex items-center gap-1.5 text-[11px] text-zinc-600">
-                <Calendar size={11} />
-                {new Date(note.updatedAt).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className="flex-1 px-5 py-4 overflow-y-auto">
-          {note.content ? (
-            <p className="text-zinc-400 text-sm leading-relaxed">
-              {note.content}
-            </p>
-          ) : (
-            <p className="text-zinc-700 text-sm italic">No content yet...</p>
-          )}
-        </div>
-      </div>
-    </Drawer>
+      </Drawer>
+    </LexicalComposer>
   );
 }

--- a/shared/components/ui/note/NoteEditor.tsx
+++ b/shared/components/ui/note/NoteEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer";
@@ -13,7 +13,7 @@ import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { TRANSFORMERS } from "@lexical/markdown";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
-import type { EditorState } from "lexical";
+import { ParagraphNode, type EditorState } from "lexical";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { CodeNode } from "@lexical/code";
 import { LinkNode } from "@lexical/link";
@@ -34,7 +34,7 @@ type NoteEditorProps = {
   saveStatus?: SaveStatus;
 };
 
-const editorTheme = {
+export const editorTheme = {
   root: "outline-none text-zinc-300 text-sm leading-relaxed",
   paragraph: "mb-2",
   heading: {
@@ -59,11 +59,12 @@ const editorTheme = {
   code: "block font-mono text-xs bg-zinc-800/80 border border-zinc-700/60 text-zinc-300 p-4 rounded-xl my-3 overflow-x-auto",
 };
 
-const editorConfig: InitialConfigType = {
+export const editorConfig: InitialConfigType = {
   namespace: "inkwell-note-editor",
   theme: editorTheme,
   onError: (error: Error) => console.error(error),
   nodes: [
+    ParagraphNode,
     HorizontalRuleNode,
     CodeNode,
     HeadingNode,
@@ -82,7 +83,6 @@ function RestoreContentPlugin({ content }: { content: string }) {
     if (restored.current || !content) return;
     try {
       const state = editor.parseEditorState(content);
-      console.log("State (JSON to text) ->:", state);
       editor.setEditorState(state);
       restored.current = true;
     } catch {
@@ -94,30 +94,14 @@ function RestoreContentPlugin({ content }: { content: string }) {
 }
 
 export function NoteEditor({
-  initialTitle = "Untitled",
+  initialTitle,
   initialContent = "",
   onTitleChange,
   onContentChange,
   onClose,
 }: NoteEditorProps) {
-  const [title, setTitle] = useState(initialTitle);
-  const titleRef = useRef<HTMLTextAreaElement>(null);
-
-  const autoResizeTitle = useCallback(() => {
-    const el = titleRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${el.scrollHeight}px`;
-  }, []);
-
-  useEffect(() => {
-    autoResizeTitle();
-  }, [autoResizeTitle]);
-
   const handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setTitle(e.target.value);
     onTitleChange?.(e.target.value);
-    autoResizeTitle();
   };
 
   const handleTitleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -147,15 +131,13 @@ export function NoteEditor({
         )}
       </div>
 
-      <div className="px-8 pb-3">
+      <div className="px-8">
         <textarea
-          ref={titleRef}
-          value={title}
+          value={initialTitle}
           onChange={handleTitleChange}
           onKeyDown={handleTitleKeyDown}
           placeholder="Untitled"
-          rows={1}
-          className="w-full z-10 !text-white outline-none text-3xl font-semibold tracking-tight placeholder:text-zinc-500 leading-tight"
+          className="w-full z-10 !text-white min-h-auto outline-none resize-none overflow-y-hidden overflow-x-auto max-h-40 text-nowrap text-3xl font-semibold tracking-tight placeholder:text-zinc-500 leading-tight"
         />
       </div>
 


### PR DESCRIPTION
This pull request introduces a new note viewer/editor page using Lexical, improves note fetching and editing workflows, and enhances both UI and infrastructure for note handling. The most significant changes include the creation of a dedicated `NotePage` component for viewing and editing notes, the addition of a utility for converting Lexical JSON to Markdown, and improvements to the note fetching and creation logic. There are also UI enhancements and dependency updates to support these new features.

**Note Viewing and Editing Improvements:**

* Added a new `NotePage` component at `app/(dashboard)/dashboard/notes/[slug]/NotePage.tsx` that uses Lexical for rich text editing, supports auto-saving, and updates notes via mutations. This component is now used in the `[slug]/page.tsx` route.
* Updated the note drawer (`NoteDrawer.tsx`) to use Lexical for rendering note content, ensuring consistency between the drawer and the main editor. 

**Backend and Utility Enhancements:**

* Added a `getNote` query to `convex/myFunctions.ts` for fetching a single note by slug, with authentication and authorization checks.
* Improved the note creation mutation to generate slugs based on the full title (not truncated), reducing potential slug collisions.
* Added a utility function `jsonToMarkdown` in `app/lib/utils/utils.ts` to convert Lexical editor JSON content to Markdown using the new `@lexical/headless` package.

**UI/UX Improvements:**

* Customized the scrollbar appearance in `app/globals.css` for better aesthetics and usability.
* Changed the default draft title in the notes list page to an empty string for a cleaner user experience.
* Removed a debug log from the note creation handler.

**Dependency Updates:**

* Added `@lexical/headless` to dependencies and updated `pnpm-lock.yaml` to support headless Lexical operations and new test dependencies. 