### PR TITLE
fix: resolve scroll in dashboard layout

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,12 +8,13 @@ export default function DashboardLayout({
 }) {
   return (
     <AuthGuard>
-      <main className="flex h-dvh w-full font-host overflow-hidden">
+      <main className="flex h-screen min-h-0 w-full font-host">
         <aside>
           <DashboardSidenav />
         </aside>
-        {/* TODO: Solve layout scroll problem */}
-        <div className="flex-1 p-4 h-full">{children}</div>
+        <div className="flex-1 p-4 h-full overflow-y-auto min-h-0">
+          {children}
+        </div>
       </main>
     </AuthGuard>
   );

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -1,3 +1,4 @@
+import { ReactLenis } from "lenis/react";
 import Header from "@/shared/components/layout/Header";
 
 export default function RootLayout({
@@ -8,6 +9,7 @@ export default function RootLayout({
   return (
     <>
       <Header />
+      <ReactLenis root />
       {children}
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Host_Grotesk } from "next/font/google";
-import { ReactLenis } from "lenis/react";
 import "./globals.css";
 import { ConvexClientProvider } from "@/shared/components/providers/convex-client-provider";
 import { Toast } from "@/shared/components/ui";
@@ -35,9 +34,8 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${hostGrotesk.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="h-full flex flex-col">
         <ConvexClientProvider>
-          <ReactLenis root />
           {children}
           <Toast />
         </ConvexClientProvider>


### PR DESCRIPTION
# Overview

This PR introduces a fix for #10, the error was `lenis` module, now being able to scroll whenever is needed

## Key Change

### Move ReactLenis From Main Layout to Root Layout

Having Lenis in the main layout prevented scrolling in sub-layouts so I moved it to `(dashboard)/layout.tsx` so we can scroll in every page of the dashboard layout.

