### PR TITLE
Feat/custom components

### DIFF
--- a/app/(auth)/auth/reset-password/page.tsx
+++ b/app/(auth)/auth/reset-password/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import { ResetPasswordPage } from "@/modules/auth";
 
 export default function Page() {
-  return <ResetPasswordPage />;
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordPage />
+    </Suspense>
+  );
 }

--- a/app/(dashboard)/dashboard/settings/page.tsx
+++ b/app/(dashboard)/dashboard/settings/page.tsx
@@ -1,7 +1,5 @@
-export default function SettingsPage() {
-  return (
-    <div>
+import { SettingsPage } from "@/modules/settings";
 
-    </div>
-  )
+export default function Page() {
+  return <SettingsPage />;
 }

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -6,6 +6,9 @@ import Link from "next/link";
 import { ArrowRight, Sparkles } from "lucide-react";
 
 import { Badge, Chip, IconBox } from "@/shared/ui";
+import { FeaturesGrid } from "@/shared/layout/landing/features-grid";
+import { Faq } from "@/shared/layout/landing/faq";
+import { Footer } from "@/shared/layout/landing/footer";
 
 function splitCharsPreservingBreaks(el: HTMLElement) {
   const html = el.innerHTML;
@@ -141,7 +144,8 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <main className="relative flex h-dvh font-host overflow-hidden bg-zinc-950">
+    <main className="font-host bg-zinc-950">
+      <section className="relative flex min-h-dvh overflow-hidden">
       <div
         className="absolute inset-0 bg-cover bg-center opacity-25 mix-blend-luminosity"
         style={{ backgroundImage: "url('/landing/hero_background.png')" }}
@@ -221,6 +225,11 @@ export default function LandingPage() {
           ))}
         </div>
       </div>
+      </section>
+
+      <FeaturesGrid />
+      <Faq />
+      <Footer />
     </main>
   );
 }

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,9 +1,30 @@
 import { convexAuth } from "@convex-dev/auth/server";
 import { Password } from "@convex-dev/auth/providers/Password";
+import type { EmailConfig } from "@auth/core/providers";
+
+const ConsoleOTP: EmailConfig = {
+  id: "console-otp",
+  type: "email",
+  name: "Console OTP",
+  from: "Inkwell <noreply@inkwell.app>",
+  maxAge: 60 * 15,
+  async generateVerificationToken() {
+    return Array.from({ length: 6 }, () =>
+      Math.floor(Math.random() * 10),
+    ).join("");
+  },
+  async sendVerificationRequest({ identifier, token }) {
+    console.warn(
+      `[auth] password reset requested for ${identifier} — code: ${token}`,
+    );
+  },
+  options: {},
+};
 
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [
     Password({
+      reset: ConsoleOTP,
       profile(params, _ctx) {
         return {
           name: params.name as string,

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,5 +1,6 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
-import { query } from "./_generated/server";
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
 
 export const getUserInfo = query({
   handler: async (ctx) => {
@@ -14,5 +15,37 @@ export const getUserInfo = query({
     }
 
     return identity;
+  },
+});
+
+export const updateProfile = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const trimmed = args.name.trim();
+    if (trimmed.length < 2) throw new Error("Name must be at least 2 characters");
+
+    await ctx.db.patch("users", userId, { name: trimmed });
+  },
+});
+
+export const deleteAccount = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const notes = await ctx.db
+      .query("notes")
+      .withIndex("by_author_id", (q) => q.eq("authorId", userId))
+      .collect();
+
+    for (const note of notes) {
+      await ctx.db.delete("notes", note._id);
+    }
+
+    await ctx.db.delete("users", userId);
   },
 });

--- a/src/modules/ai-chat/domain/services/prompt-suggestions.ts
+++ b/src/modules/ai-chat/domain/services/prompt-suggestions.ts
@@ -1,0 +1,19 @@
+import type { AttachedNote } from "../entities/chat-message";
+
+export const dashboardSuggestions: ReadonlyArray<string> = [
+  "Summarize my recent notes",
+  "What did I write about last week?",
+  "Help me organize my ideas",
+];
+
+export const noteSuggestions: ReadonlyArray<string> = [
+  "Summarize this note",
+  "Suggest improvements",
+  "Extract action items",
+];
+
+export function getSuggestions(
+  attachedNote: AttachedNote | null,
+): ReadonlyArray<string> {
+  return attachedNote ? noteSuggestions : dashboardSuggestions;
+}

--- a/src/modules/ai-chat/infrastructure/stores/ai-chat.store.ts
+++ b/src/modules/ai-chat/infrastructure/stores/ai-chat.store.ts
@@ -21,6 +21,8 @@ type AIChatStore = {
   addAttachedFile: (file: AttachedFile) => void;
   removeAttachedFile: (id: string) => void;
   setLoading: (loading: boolean) => void;
+  clearContext: () => void;
+  removeLastAssistantMessage: () => void;
 };
 
 export const useAIChatStore = create<AIChatStore>((set) => ({
@@ -62,4 +64,26 @@ export const useAIChatStore = create<AIChatStore>((set) => ({
       attachedFiles: state.attachedFiles.filter((f) => f.id !== id),
     })),
   setLoading: (loading) => set({ isLoading: loading }),
+  clearContext: () =>
+    set((state) => ({
+      contextMessages: {
+        ...state.contextMessages,
+        [state.currentContext]: [],
+      },
+      attachedFiles: [],
+    })),
+  removeLastAssistantMessage: () =>
+    set((state) => {
+      const ctx = state.currentContext;
+      const messages = state.contextMessages[ctx] ?? [];
+      if (messages.length === 0) return {};
+      const last = messages[messages.length - 1];
+      if (last.role !== "assistant") return {};
+      return {
+        contextMessages: {
+          ...state.contextMessages,
+          [ctx]: messages.slice(0, -1),
+        },
+      };
+    }),
 }));

--- a/src/modules/ai-chat/ui/components/AIChatMessage.tsx
+++ b/src/modules/ai-chat/ui/components/AIChatMessage.tsx
@@ -1,12 +1,30 @@
+"use client";
+
+import { Copy, RotateCcw } from "lucide-react";
+
+import { Tooltip } from "@/shared/ui/tooltip";
+import { useToast } from "@/shared/hooks/use-toast";
 import type { ChatMessage } from "../../domain/entities/chat-message";
 import { AIChatMarkdown } from "./AIChatMarkdown";
 
 type Props = {
   message: ChatMessage;
+  isLast?: boolean;
+  onRegenerate?: () => void;
 };
 
-export function AIChatMessage({ message }: Props) {
+export function AIChatMessage({ message, isLast, onRegenerate }: Props) {
+  const { toast } = useToast();
   const isUser = message.role === "user";
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+      toast.success({ title: "Copied to clipboard" });
+    } catch {
+      toast.error({ title: "Could not copy" });
+    }
+  };
 
   if (isUser) {
     return (
@@ -19,9 +37,31 @@ export function AIChatMessage({ message }: Props) {
   }
 
   return (
-    <div className="flex justify-start">
+    <div className="group flex flex-col items-start">
       <div className="max-w-[88%] bg-zinc-800/60 rounded-2xl rounded-tl-sm px-4 py-2.5">
         <AIChatMarkdown content={message.content} />
+      </div>
+      <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+        <Tooltip content="Copy">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="w-6 h-6 flex items-center justify-center rounded-lg text-zinc-600 hover:text-zinc-300 hover:bg-zinc-800 transition-colors cursor-pointer"
+          >
+            <Copy className="w-3 h-3" />
+          </button>
+        </Tooltip>
+        {isLast && onRegenerate && (
+          <Tooltip content="Regenerate">
+            <button
+              type="button"
+              onClick={onRegenerate}
+              className="w-6 h-6 flex items-center justify-center rounded-lg text-zinc-600 hover:text-emerald-400 hover:bg-emerald-500/10 transition-colors cursor-pointer"
+            >
+              <RotateCcw className="w-3 h-3" />
+            </button>
+          </Tooltip>
+        )}
       </div>
     </div>
   );

--- a/src/modules/ai-chat/ui/components/AIChatPanel.tsx
+++ b/src/modules/ai-chat/ui/components/AIChatPanel.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useRef } from "react";
 import { usePathname, useParams } from "next/navigation";
-import { X, Sparkles } from "lucide-react";
+import { Eraser, Sparkles, X } from "lucide-react";
 import gsap from "gsap";
 
+import { Tooltip } from "@/shared/ui/tooltip";
 import { useNote } from "@/modules/notes";
 import { extractTextFromLexicalJSON } from "@/lib/lexical";
 
@@ -14,6 +15,7 @@ import {
   dashboardContextId,
   noteContextId,
 } from "../../domain/entities/chat-context";
+import { getSuggestions } from "../../domain/services/prompt-suggestions";
 import type { ChatMessage } from "../../domain/entities/chat-message";
 
 import { AIChatMessage } from "./AIChatMessage";
@@ -39,6 +41,8 @@ export function AIChatPanel() {
     setAttachedNote,
     setLoading,
     setContext,
+    clearContext,
+    removeLastAssistantMessage,
   } = useAIChatStore();
 
   const noteSlug =
@@ -110,13 +114,11 @@ export function AIChatPanel() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
 
-  const handleSubmit = async (text: string) => {
-    addMessage({ role: "user", content: text });
+  const runPrompt = async (text: string, history: ChatMessage[]) => {
     setLoading(true);
-
     try {
       const response = await sendMessage({
-        history: messages,
+        history,
         text,
         attachedFiles,
         attachedNote,
@@ -132,6 +134,22 @@ export function AIChatPanel() {
     }
   };
 
+  const handleSubmit = async (text: string) => {
+    addMessage({ role: "user", content: text });
+    await runPrompt(text, messages);
+  };
+
+  const handleRegenerate = async () => {
+    if (isLoading) return;
+    const lastUser = [...messages]
+      .reverse()
+      .find((m) => m.role === "user");
+    if (!lastUser) return;
+    removeLastAssistantMessage();
+    const historyWithoutLast = messages.slice(0, -1);
+    await runPrompt(lastUser.content, historyWithoutLast);
+  };
+
   return (
     <div
       ref={panelRef}
@@ -143,9 +161,21 @@ export function AIChatPanel() {
         <span className="flex-1 text-sm font-medium text-zinc-100">
           Inkwell Assistant
         </span>
+        {messages.length > 0 && (
+          <Tooltip content="Clear chat">
+            <button
+              type="button"
+              onClick={clearContext}
+              className="w-7 h-7 flex items-center justify-center rounded-xl text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors cursor-pointer"
+            >
+              <Eraser className="w-3.5 h-3.5" />
+            </button>
+          </Tooltip>
+        )}
         <button
+          type="button"
           onClick={close}
-          className="w-7 h-7 flex items-center justify-center rounded-xl text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors"
+          className="w-7 h-7 flex items-center justify-center rounded-xl text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800 transition-colors cursor-pointer"
         >
           <X className="w-4 h-4" />
         </button>
@@ -153,15 +183,35 @@ export function AIChatPanel() {
 
       <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-3 min-h-0">
         {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full gap-2 py-8 text-center">
+          <div className="flex flex-col items-center justify-center h-full gap-4 py-8 text-center">
             <Sparkles className="w-8 h-8 text-zinc-700" />
             <p className="text-sm text-zinc-500 max-w-[220px]">
-              Ask me anything about your notes or writing.
+              {attachedNote
+                ? "Ask anything about this note."
+                : "Ask anything about your notes or writing."}
             </p>
+            <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
+              {getSuggestions(attachedNote).map((prompt) => (
+                <button
+                  key={prompt}
+                  type="button"
+                  disabled={isLoading}
+                  onClick={() => handleSubmit(prompt)}
+                  className="text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800/40 hover:bg-zinc-800/80 border border-zinc-800 hover:border-zinc-700 rounded-xl px-3 py-2 transition-colors text-left disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
           </div>
         )}
-        {messages.map((message) => (
-          <AIChatMessage key={message.id} message={message} />
+        {messages.map((message, idx) => (
+          <AIChatMessage
+            key={message.id}
+            message={message}
+            isLast={idx === messages.length - 1}
+            onRegenerate={handleRegenerate}
+          />
         ))}
         {isLoading && <AIChatTyping />}
         <div ref={messagesEndRef} />

--- a/src/modules/auth/domain/repositories/auth.repository.ts
+++ b/src/modules/auth/domain/repositories/auth.repository.ts
@@ -11,6 +11,12 @@ export type SignUpPayload = {
   name: string;
 };
 
+export type ResetVerifyPayload = {
+  email: string;
+  code: string;
+  newPassword: string;
+};
+
 export type AuthSession = {
   isAuthenticated: boolean;
   isLoading: boolean;
@@ -20,6 +26,10 @@ export type AuthMutations = {
   signIn: (payload: SignInPayload) => Promise<void>;
   signUp: (payload: SignUpPayload) => Promise<void>;
   signOut: () => Promise<void>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  confirmPasswordReset: (payload: ResetVerifyPayload) => Promise<void>;
+  updateProfile: (name: string) => Promise<void>;
+  deleteAccount: () => Promise<void>;
 };
 
 export type AuthRepositoryPort = {

--- a/src/modules/auth/infrastructure/repositories/convex-auth.repository.ts
+++ b/src/modules/auth/infrastructure/repositories/convex-auth.repository.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery, useConvexAuth } from "convex/react";
+import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { useAuthActions } from "@convex-dev/auth/react";
 import { api } from "@/convex/_generated/api";
 import type {
@@ -21,6 +21,9 @@ export const convexAuthRepository: AuthRepositoryPort = {
 
   useMutations: (): AuthMutations => {
     const { signIn, signOut } = useAuthActions();
+    const updateProfileMutation = useMutation(api.users.updateProfile);
+    const deleteAccountMutation = useMutation(api.users.deleteAccount);
+
     return {
       signIn: async ({ email, password }) => {
         await signIn("password", { email, password, flow: "signIn" });
@@ -30,6 +33,23 @@ export const convexAuthRepository: AuthRepositoryPort = {
       },
       signOut: async () => {
         await signOut();
+      },
+      requestPasswordReset: async (email) => {
+        await signIn("password", { email, flow: "reset" });
+      },
+      confirmPasswordReset: async ({ email, code, newPassword }) => {
+        await signIn("password", {
+          email,
+          code,
+          newPassword,
+          flow: "reset-verification",
+        });
+      },
+      updateProfile: async (name) => {
+        await updateProfileMutation({ name });
+      },
+      deleteAccount: async () => {
+        await deleteAccountMutation({});
       },
     };
   },

--- a/src/modules/auth/ui/pages/forgot-password-page.tsx
+++ b/src/modules/auth/ui/pages/forgot-password-page.tsx
@@ -9,6 +9,8 @@ import { z } from "zod";
 import gsap from "gsap";
 
 import { Button, Input } from "@/shared/ui";
+import { useToast } from "@/shared/hooks/use-toast";
+import { useAuthActions } from "../../infrastructure/hooks/use-auth";
 
 const forgotSchema = z.object({
   email: z
@@ -20,6 +22,9 @@ const forgotSchema = z.object({
 type ForgotSchema = z.infer<typeof forgotSchema>;
 
 export function ForgotPasswordPage() {
+  const { requestPasswordReset } = useAuthActions();
+  const { toast } = useToast();
+
   const [submitted, setSubmitted] = useState(false);
   const [sentTo, setSentTo] = useState("");
 
@@ -80,9 +85,17 @@ export function ForgotPasswordPage() {
   }, [submitted]);
 
   const onSubmit = async (data: ForgotSchema) => {
-    await new Promise((r) => setTimeout(r, 1500));
-    setSentTo(data.email);
-    setSubmitted(true);
+    try {
+      await requestPasswordReset(data.email);
+      setSentTo(data.email);
+      setSubmitted(true);
+    } catch (error) {
+      console.error("Forgot password failed:", error);
+      toast.error({
+        title: "Could not send reset email",
+        description: "Check the address and try again.",
+      });
+    }
   };
 
   if (submitted) {
@@ -106,6 +119,14 @@ export function ForgotPasswordPage() {
         </div>
 
         <div className="space-y-3">
+          <Link
+            href={`/auth/reset-password?email=${encodeURIComponent(sentTo)}`}
+            className="w-full flex items-center justify-center gap-2 rounded-2xl bg-white text-zinc-900 hover:bg-zinc-100 text-sm font-medium py-3.5 transition-colors duration-200"
+          >
+            I have the code
+            <ArrowRight size={15} />
+          </Link>
+
           <Button
             type="button"
             variant="secondary"

--- a/src/modules/auth/ui/pages/login-page.tsx
+++ b/src/modules/auth/ui/pages/login-page.tsx
@@ -190,7 +190,9 @@ export function LoginPage() {
       <div ref={oauthRef} className="space-y-3">
         <button
           type="button"
-          className="w-full cursor-pointer flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-700 text-zinc-300 text-sm py-3.5 transition-all duration-300"
+          disabled
+          aria-label="Continue with Google — coming soon"
+          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/20 text-zinc-500 text-sm py-3.5 opacity-50 cursor-not-allowed"
         >
           <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor">
             <path
@@ -211,13 +213,21 @@ export function LoginPage() {
             />
           </svg>
           Continue with Google
+          <span className="text-[10px] tracking-wide uppercase text-zinc-600 border border-zinc-700/60 rounded-full px-2 py-0.5">
+            soon
+          </span>
         </button>
 
         <button
           type="button"
-          className="w-full flex items-center cursor-pointer justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-700 text-zinc-300 text-sm py-3.5 transition-all duration-300"
+          disabled
+          aria-label="Continue with GitHub — coming soon"
+          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/20 text-zinc-500 text-sm py-3.5 opacity-50 cursor-not-allowed"
         >
           Continue with GitHub
+          <span className="text-[10px] tracking-wide uppercase text-zinc-600 border border-zinc-700/60 rounded-full px-2 py-0.5">
+            soon
+          </span>
         </button>
       </div>
 

--- a/src/modules/auth/ui/pages/register-page.tsx
+++ b/src/modules/auth/ui/pages/register-page.tsx
@@ -174,7 +174,9 @@ export function RegisterPage() {
       <div ref={oauthRef} className="space-y-3">
         <button
           type="button"
-          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-700 text-zinc-300 text-sm py-3.5 transition-all duration-300"
+          disabled
+          aria-label="Continue with Google — coming soon"
+          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/20 text-zinc-500 text-sm py-3.5 opacity-50 cursor-not-allowed"
         >
           <svg viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor">
             <path
@@ -195,13 +197,21 @@ export function RegisterPage() {
             />
           </svg>
           Continue with Google
+          <span className="text-[10px] tracking-wide uppercase text-zinc-600 border border-zinc-700/60 rounded-full px-2 py-0.5">
+            soon
+          </span>
         </button>
 
         <button
           type="button"
-          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-700 text-zinc-300 text-sm py-3.5 transition-all duration-300"
+          disabled
+          aria-label="Continue with GitHub — coming soon"
+          className="w-full flex items-center justify-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-800/20 text-zinc-500 text-sm py-3.5 opacity-50 cursor-not-allowed"
         >
           Continue with GitHub
+          <span className="text-[10px] tracking-wide uppercase text-zinc-600 border border-zinc-700/60 rounded-full px-2 py-0.5">
+            soon
+          </span>
         </button>
       </div>
 

--- a/src/modules/auth/ui/pages/reset-password-page.tsx
+++ b/src/modules/auth/ui/pages/reset-password-page.tsx
@@ -1,3 +1,194 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, Eye, EyeOff, Lock } from "lucide-react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import gsap from "gsap";
+
+import { Button, Field, Input } from "@/shared/ui";
+import { useToast } from "@/shared/hooks/use-toast";
+import {
+  resetPasswordSchema,
+  type ResetPasswordSchema,
+} from "../schemas/reset-password.schema";
+import { useAuthActions } from "../../infrastructure/hooks/use-auth";
+
 export function ResetPasswordPage() {
-  return <></>;
+  const { confirmPasswordReset } = useAuthActions();
+  const { toast } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const headingRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const footerRef = useRef<HTMLParagraphElement>(null);
+
+  const initialEmail = searchParams.get("email") ?? "";
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      email: initialEmail,
+      code: "",
+      newPassword: "",
+      confirmPassword: "",
+    },
+  });
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      gsap
+        .timeline({ defaults: { ease: "power3.out" } })
+        .fromTo(
+          headingRef.current,
+          { opacity: 0, y: 20 },
+          { opacity: 1, y: 0, duration: 0.7 },
+        )
+        .fromTo(
+          formRef.current,
+          { opacity: 0, y: 24 },
+          { opacity: 1, y: 0, duration: 0.8 },
+          "-=0.4",
+        )
+        .fromTo(
+          footerRef.current,
+          { opacity: 0 },
+          { opacity: 1, duration: 0.5 },
+          "-=0.3",
+        );
+    }, containerRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  const onSubmit = async (data: ResetPasswordSchema) => {
+    try {
+      await confirmPasswordReset({
+        email: data.email,
+        code: data.code,
+        newPassword: data.newPassword,
+      });
+      toast.success({
+        title: "Password updated",
+        description: "Sign in with your new password.",
+      });
+      router.push("/login");
+    } catch (error) {
+      console.error("Reset failed:", error);
+      toast.error({
+        title: "Could not reset password",
+        description: "Check the code and try again.",
+      });
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="w-full space-y-8">
+      <div ref={headingRef}>
+        <div className="w-12 h-12 rounded-2xl bg-zinc-800 border border-zinc-700 flex items-center justify-center mb-5">
+          <Lock size={20} className="text-zinc-300" />
+        </div>
+        <h2 className="text-white text-2xl font-light tracking-tight">
+          Set a new password
+        </h2>
+        <p className="text-zinc-500 text-sm mt-1.5 leading-relaxed">
+          Enter the 6-digit code we sent to your email and pick a new password.
+        </p>
+      </div>
+
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        <Input
+          {...register("email")}
+          label="Email"
+          type="email"
+          placeholder="you@example.com"
+          error={errors.email?.message}
+          autoComplete="email"
+        />
+
+        <Field label="Verification code" error={errors.code?.message}>
+          <Input
+            {...register("code")}
+            inputMode="numeric"
+            maxLength={6}
+            placeholder="123456"
+            autoComplete="one-time-code"
+          />
+        </Field>
+
+        <Input
+          {...register("newPassword")}
+          label="New password"
+          type={showPassword ? "text" : "password"}
+          placeholder="••••••••"
+          error={errors.newPassword?.message}
+          autoComplete="new-password"
+          trailing={
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="text-zinc-600 hover:text-zinc-400 transition-colors duration-200 cursor-pointer"
+            >
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          }
+        />
+
+        <Input
+          {...register("confirmPassword")}
+          label="Confirm password"
+          type={showConfirm ? "text" : "password"}
+          placeholder="••••••••"
+          error={errors.confirmPassword?.message}
+          autoComplete="new-password"
+          trailing={
+            <button
+              type="button"
+              onClick={() => setShowConfirm((v) => !v)}
+              className="text-zinc-600 hover:text-zinc-400 transition-colors duration-200 cursor-pointer"
+            >
+              {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          }
+        />
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="md"
+          loading={isSubmitting}
+          icon={!isSubmitting ? <ArrowRight size={15} /> : undefined}
+          iconPosition="right"
+          className="w-full mt-2"
+        >
+          Update password
+        </Button>
+      </form>
+
+      <p ref={footerRef} className="text-center text-zinc-600 text-xs">
+        <Link
+          href="/login"
+          className="flex items-center justify-center gap-1.5 text-zinc-500 hover:text-white transition-colors duration-200"
+        >
+          <ArrowLeft size={12} />
+          Back to sign in
+        </Link>
+      </p>
+    </div>
+  );
 }

--- a/src/modules/auth/ui/schemas/reset-password.schema.ts
+++ b/src/modules/auth/ui/schemas/reset-password.schema.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const resetPasswordSchema = z
+  .object({
+    email: z.string().min(1, "Email is required").email("Invalid email address"),
+    code: z
+      .string()
+      .min(1, "Enter the code we sent to your email")
+      .length(6, "The code is 6 digits"),
+    newPassword: z
+      .string()
+      .min(1, "Password is required")
+      .min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>;

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage } from "./ui/pages/settings-page";

--- a/src/modules/settings/ui/components/account-section/AccountSection.tsx
+++ b/src/modules/settings/ui/components/account-section/AccountSection.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Eye, EyeOff, ArrowRight, ShieldAlert } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { Button, Card, Input } from "@/shared/ui";
+import { useToast } from "@/shared/hooks/use-toast";
+import {
+  changePasswordSchema,
+  type ChangePasswordSchema,
+} from "../../schemas/change-password.schema";
+
+export function AccountSection() {
+  const { toast } = useToast();
+
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ChangePasswordSchema>({
+    resolver: zodResolver(changePasswordSchema),
+  });
+
+  const onSubmit = async (_data: ChangePasswordSchema) => {
+    toast.default({
+      title: "Password change is rolling out",
+      description:
+        "For now, use \"Forgot password\" from the sign-in screen to set a new one.",
+    });
+    reset();
+  };
+
+  return (
+    <Card variant="default" padding="lg">
+      <div className="space-y-5">
+        <div>
+          <h3 className="text-white text-sm font-medium tracking-tight">
+            Change password
+          </h3>
+          <p className="text-zinc-600 text-xs mt-1">
+            Update the password used to sign into Inkwell.
+          </p>
+        </div>
+
+        <div className="flex items-start gap-3 p-3 rounded-2xl bg-amber-500/5 border border-amber-500/20">
+          <ShieldAlert size={14} className="text-amber-400 mt-0.5 shrink-0" />
+          <div className="text-xs text-amber-200/80 leading-relaxed">
+            In-app password change is rolling out. For now, use{" "}
+            <Link
+              href="/forgot-password"
+              className="text-amber-300 underline underline-offset-4 decoration-amber-700/60 hover:decoration-amber-400"
+            >
+              Forgot password
+            </Link>{" "}
+            from the sign-in screen.
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <Input
+            {...register("currentPassword")}
+            label="Current password"
+            type={showCurrent ? "text" : "password"}
+            placeholder="••••••••"
+            error={errors.currentPassword?.message}
+            autoComplete="current-password"
+            trailing={
+              <button
+                type="button"
+                onClick={() => setShowCurrent((v) => !v)}
+                className="text-zinc-600 hover:text-zinc-400 transition-colors duration-200 cursor-pointer"
+              >
+                {showCurrent ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            }
+          />
+
+          <Input
+            {...register("newPassword")}
+            label="New password"
+            type={showNew ? "text" : "password"}
+            placeholder="••••••••"
+            error={errors.newPassword?.message}
+            autoComplete="new-password"
+            trailing={
+              <button
+                type="button"
+                onClick={() => setShowNew((v) => !v)}
+                className="text-zinc-600 hover:text-zinc-400 transition-colors duration-200 cursor-pointer"
+              >
+                {showNew ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            }
+          />
+
+          <Input
+            {...register("confirmPassword")}
+            label="Confirm new password"
+            type={showConfirm ? "text" : "password"}
+            placeholder="••••••••"
+            error={errors.confirmPassword?.message}
+            autoComplete="new-password"
+            trailing={
+              <button
+                type="button"
+                onClick={() => setShowConfirm((v) => !v)}
+                className="text-zinc-600 hover:text-zinc-400 transition-colors duration-200 cursor-pointer"
+              >
+                {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            }
+          />
+
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              loading={isSubmitting}
+              icon={!isSubmitting ? <ArrowRight size={14} /> : undefined}
+              iconPosition="right"
+            >
+              Update password
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Card>
+  );
+}

--- a/src/modules/settings/ui/components/account-section/index.ts
+++ b/src/modules/settings/ui/components/account-section/index.ts
@@ -1,0 +1,1 @@
+export { AccountSection } from "./AccountSection";

--- a/src/modules/settings/ui/components/danger-zone-section/DangerZoneSection.tsx
+++ b/src/modules/settings/ui/components/danger-zone-section/DangerZoneSection.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Download, Trash2, TriangleAlert } from "lucide-react";
+
+import { Button, Card, Dialog, Input } from "@/shared/ui";
+import { useToast } from "@/shared/hooks/use-toast";
+import { useAllNotes } from "@/modules/notes";
+import { useAuthActions } from "@/modules/auth";
+
+function todayStamp() {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function DangerZoneSection() {
+  const { notes, isLoading } = useAllNotes();
+  const { deleteAccount, signOut } = useAuthActions();
+  const { toast } = useToast();
+  const router = useRouter();
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+
+  const handleExport = () => {
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      noteCount: notes?.length ?? 0,
+      notes: notes ?? [],
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `inkwell-export-${todayStamp()}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    toast.success({
+      title: "Export downloaded",
+      description: `${payload.noteCount} note${payload.noteCount === 1 ? "" : "s"} saved to your device.`,
+    });
+  };
+
+  const handleDelete = async () => {
+    try {
+      setDeleting(true);
+      await deleteAccount();
+      await signOut();
+      toast.success({
+        title: "Account deleted",
+        description: "Your notes and account have been removed.",
+      });
+      router.push("/");
+    } catch (error) {
+      console.error("Account deletion failed:", error);
+      toast.error({
+        title: "Could not delete account",
+        description: "Try again in a moment.",
+      });
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setConfirmText("");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card
+        variant="default"
+        padding="lg"
+        className="border-red-900/40 bg-red-950/10"
+      >
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-white text-sm font-medium tracking-tight flex items-center gap-2">
+              <Download size={14} className="text-zinc-400" />
+              Export my notes
+            </h3>
+            <p className="text-zinc-500 text-xs mt-1 max-w-md leading-relaxed">
+              Download every note as a single JSON file. Includes archived and
+              favorited notes. Take your data with you, anytime.
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<Download size={13} />}
+            disabled={isLoading || (notes?.length ?? 0) === 0}
+            onClick={handleExport}
+          >
+            Download JSON
+          </Button>
+        </div>
+      </Card>
+
+      <Card
+        variant="default"
+        padding="lg"
+        className="border-red-900/40 bg-red-950/10"
+      >
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-white text-sm font-medium tracking-tight flex items-center gap-2">
+              <TriangleAlert size={14} className="text-red-400" />
+              Delete account
+            </h3>
+            <p className="text-zinc-500 text-xs mt-1 max-w-md leading-relaxed">
+              Permanently delete your Inkwell account and every note tied to
+              it. This action cannot be undone.
+            </p>
+          </div>
+          <Button
+            variant="danger"
+            size="sm"
+            icon={<Trash2 size={13} />}
+            onClick={() => setDeleteOpen(true)}
+          >
+            Delete account
+          </Button>
+        </div>
+      </Card>
+
+      <Dialog
+        open={deleteOpen}
+        onClose={() => {
+          if (!deleting) {
+            setDeleteOpen(false);
+            setConfirmText("");
+          }
+        }}
+        title="Delete your account?"
+        description="Your notes, favorites, archive, and account will be permanently removed. We won't be able to recover them."
+        size="md"
+      >
+        <div className="space-y-4">
+          <div className="rounded-2xl border border-red-900/40 bg-red-950/20 px-4 py-3">
+            <p className="text-red-300/80 text-xs leading-relaxed">
+              {notes?.length ?? 0} note
+              {(notes?.length ?? 0) === 1 ? "" : "s"} will be deleted.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-zinc-500 text-xs tracking-wide uppercase">
+              Type DELETE to confirm
+            </label>
+            <Input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+              autoFocus
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={deleting}
+              onClick={() => {
+                setDeleteOpen(false);
+                setConfirmText("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              loading={deleting}
+              disabled={confirmText !== "DELETE" || deleting}
+              onClick={handleDelete}
+            >
+              Permanently delete
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/modules/settings/ui/components/danger-zone-section/index.ts
+++ b/src/modules/settings/ui/components/danger-zone-section/index.ts
@@ -1,0 +1,1 @@
+export { DangerZoneSection } from "./DangerZoneSection";

--- a/src/modules/settings/ui/components/profile-section/ProfileSection.tsx
+++ b/src/modules/settings/ui/components/profile-section/ProfileSection.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Mail } from "lucide-react";
+
+import { Avatar, Button, Card, Field, Input } from "@/shared/ui";
+import { useToast } from "@/shared/hooks/use-toast";
+import {
+  useAuthActions,
+  useCurrentUser,
+} from "@/modules/auth";
+
+export function ProfileSection() {
+  const { user, isLoading } = useCurrentUser();
+  const { updateProfile } = useAuthActions();
+  const { toast } = useToast();
+
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (user?.name) setName(user.name);
+  }, [user?.name]);
+
+  if (isLoading || !user) {
+    return (
+      <Card variant="default" padding="lg">
+        <p className="text-zinc-500 text-sm">Loading profile…</p>
+      </Card>
+    );
+  }
+
+  const dirty = name.trim() !== (user.name ?? "").trim();
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    if (trimmed.length < 2) {
+      toast.error({
+        title: "Name too short",
+        description: "Use at least 2 characters.",
+      });
+      return;
+    }
+    try {
+      setSaving(true);
+      await updateProfile(trimmed);
+      toast.success({ title: "Profile updated" });
+    } catch (error) {
+      console.error("Failed to update profile:", error);
+      toast.error({
+        title: "Could not save profile",
+        description: "Try again in a moment.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card variant="default" padding="lg">
+        <div className="flex items-start gap-5">
+          <Avatar src={undefined} name={user.name ?? user.email ?? "U"} size="lg" />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-white text-sm font-medium">
+              {user.name ?? "Unnamed"}
+            </h3>
+            <p className="text-zinc-600 text-xs mt-1 flex items-center gap-1.5">
+              <Mail size={11} />
+              {user.email}
+            </p>
+            <p className="text-zinc-700 text-[11px] mt-3">
+              Avatar uploads coming soon.
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <Card variant="default" padding="lg">
+        <div className="space-y-5">
+          <div>
+            <h3 className="text-white text-sm font-medium tracking-tight">
+              Display name
+            </h3>
+            <p className="text-zinc-600 text-xs mt-1">
+              Shown across Inkwell and in your sidenav.
+            </p>
+          </div>
+
+          <Field label="Name">
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              autoComplete="name"
+            />
+          </Field>
+
+          <Field label="Email">
+            <Input
+              value={user.email ?? ""}
+              disabled
+              className="text-zinc-500"
+            />
+            <p className="text-zinc-700 text-[11px] mt-1.5 px-1">
+              Email changes require contacting support.
+            </p>
+          </Field>
+
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              size="sm"
+              loading={saving}
+              disabled={!dirty || saving}
+              onClick={handleSave}
+            >
+              Save changes
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/settings/ui/components/profile-section/index.ts
+++ b/src/modules/settings/ui/components/profile-section/index.ts
@@ -1,0 +1,1 @@
+export { ProfileSection } from "./ProfileSection";

--- a/src/modules/settings/ui/components/settings-tabs/SettingsTabs.tsx
+++ b/src/modules/settings/ui/components/settings-tabs/SettingsTabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type SettingsTabId = "profile" | "account" | "danger";
+
+type Tab = {
+  id: SettingsTabId;
+  label: string;
+  icon: ReactNode;
+};
+
+type SettingsTabsProps = {
+  tabs: Tab[];
+  active: SettingsTabId;
+  onChange: (id: SettingsTabId) => void;
+};
+
+export function SettingsTabs({ tabs, active, onChange }: SettingsTabsProps) {
+  return (
+    <div className="flex items-center gap-1 border-b border-zinc-800/80">
+      {tabs.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onChange(tab.id)}
+            className={`relative flex items-center gap-2 px-4 py-3 text-sm transition-colors cursor-pointer ${
+              isActive
+                ? "text-zinc-100"
+                : "text-zinc-500 hover:text-zinc-300"
+            }`}
+          >
+            <span className="shrink-0">{tab.icon}</span>
+            <span className="tracking-wide">{tab.label}</span>
+            {isActive && (
+              <span className="absolute bottom-0 left-3 right-3 h-px bg-zinc-100" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/modules/settings/ui/components/settings-tabs/index.ts
+++ b/src/modules/settings/ui/components/settings-tabs/index.ts
@@ -1,0 +1,1 @@
+export { SettingsTabs, type SettingsTabId } from "./SettingsTabs";

--- a/src/modules/settings/ui/pages/settings-page.tsx
+++ b/src/modules/settings/ui/pages/settings-page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ShieldAlert, TriangleAlert, User } from "lucide-react";
+import gsap from "gsap";
+
+import {
+  SettingsTabs,
+  type SettingsTabId,
+} from "../components/settings-tabs";
+import { ProfileSection } from "../components/profile-section";
+import { AccountSection } from "../components/account-section";
+import { DangerZoneSection } from "../components/danger-zone-section";
+
+const tabs = [
+  { id: "profile" as const, label: "Profile", icon: <User size={13} /> },
+  { id: "account" as const, label: "Account", icon: <ShieldAlert size={13} /> },
+  {
+    id: "danger" as const,
+    label: "Danger Zone",
+    icon: <TriangleAlert size={13} />,
+  },
+];
+
+export function SettingsPage() {
+  const [active, setActive] = useState<SettingsTabId>("profile");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sectionRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      gsap.fromTo(
+        containerRef.current,
+        { opacity: 0, y: 18 },
+        { opacity: 1, y: 0, duration: 0.55, ease: "power3.out" },
+      );
+    }, containerRef);
+    return () => ctx.revert();
+  }, []);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    gsap.fromTo(
+      el,
+      { opacity: 0, y: 12, filter: "blur(4px)" },
+      {
+        opacity: 1,
+        y: 0,
+        filter: "blur(0px)",
+        duration: 0.35,
+        ease: "power3.out",
+      },
+    );
+  }, [active]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex flex-col h-full px-6 py-6 gap-6 max-w-3xl mx-auto w-full"
+    >
+      <div>
+        <h1 className="text-white text-2xl font-light tracking-tight">
+          Settings
+        </h1>
+        <p className="text-zinc-600 text-xs mt-0.5">
+          Manage your profile, security, and data.
+        </p>
+      </div>
+
+      <SettingsTabs tabs={tabs} active={active} onChange={setActive} />
+
+      <div ref={sectionRef} key={active}>
+        {active === "profile" && <ProfileSection />}
+        {active === "account" && <AccountSection />}
+        {active === "danger" && <DangerZoneSection />}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/settings/ui/schemas/change-password.schema.ts
+++ b/src/modules/settings/ui/schemas/change-password.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required"),
+    newPassword: z
+      .string()
+      .min(1, "New password is required")
+      .min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your password"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export type ChangePasswordSchema = z.infer<typeof changePasswordSchema>;

--- a/src/shared/hooks/use-portal-mounted.ts
+++ b/src/shared/hooks/use-portal-mounted.ts
@@ -1,0 +1,9 @@
+import { useEffect, useState } from "react";
+
+export function usePortalMounted() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted;
+}

--- a/src/shared/layout/Header.tsx
+++ b/src/shared/layout/Header.tsx
@@ -58,7 +58,7 @@ export default function Header() {
         {[
           { label: "Home", href: "#" },
           { label: "Features", href: "#features" },
-          { label: "Contact", href: "#contact" },
+          { label: "FAQ", href: "#faq" },
         ].map(({ label, href }) => (
           <a
             key={label}

--- a/src/shared/layout/landing/faq/Faq.tsx
+++ b/src/shared/layout/landing/faq/Faq.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import gsap from "gsap";
+
+type Item = {
+  question: string;
+  answer: string;
+};
+
+const items: Item[] = [
+  {
+    question: "Is Inkwell really free?",
+    answer:
+      "Yes, forever. No premium tier, no usage caps. Hosting is paid by donations and the maintainer — the product never gates features behind a wall.",
+  },
+  {
+    question: "Where are my notes stored?",
+    answer:
+      "In Convex, encrypted in transit. Each note is scoped to your account; nobody else can read them. You can export everything at any time from Settings → Danger Zone.",
+  },
+  {
+    question: "Is it open source?",
+    answer:
+      "Yes. The full source lives on GitHub — read it, fork it, ship PRs. Self-hosting is on the roadmap.",
+  },
+  {
+    question: "Can I export my notes?",
+    answer:
+      "Anytime. Settings → Danger Zone → \"Download my notes (JSON)\" gives you a portable file with everything, including archived and favorited notes.",
+  },
+];
+
+function FaqRow({
+  item,
+  open,
+  onToggle,
+}: {
+  item: Item;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const body = bodyRef.current;
+    const inner = innerRef.current;
+    if (!body || !inner) return;
+
+    if (open) {
+      gsap.fromTo(
+        body,
+        { maxHeight: 0, opacity: 0 },
+        {
+          maxHeight: inner.scrollHeight,
+          opacity: 1,
+          duration: 0.35,
+          ease: "power3.out",
+        },
+      );
+    } else {
+      gsap.to(body, {
+        maxHeight: 0,
+        opacity: 0,
+        duration: 0.25,
+        ease: "power3.in",
+      });
+    }
+  }, [open]);
+
+  return (
+    <div className="border-b border-zinc-800/60">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center justify-between gap-4 py-5 text-left cursor-pointer group"
+      >
+        <span
+          className={`text-sm font-medium transition-colors ${
+            open ? "text-white" : "text-zinc-300 group-hover:text-white"
+          }`}
+        >
+          {item.question}
+        </span>
+        <ChevronDown
+          size={16}
+          className={`shrink-0 text-zinc-600 transition-transform duration-300 ${
+            open ? "rotate-180 text-zinc-300" : ""
+          }`}
+        />
+      </button>
+      <div
+        ref={bodyRef}
+        style={{ maxHeight: 0, opacity: 0, overflow: "hidden" }}
+      >
+        <div ref={innerRef} className="pb-5 pr-8">
+          <p className="text-zinc-500 text-sm leading-relaxed">{item.answer}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Faq() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const headingRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const ctx = gsap.context(() => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        const trigger = () => {
+          gsap
+            .timeline({ defaults: { ease: "power3.out" } })
+            .fromTo(
+              headingRef.current,
+              { opacity: 0, y: 20 },
+              { opacity: 1, y: 0, duration: 0.6 },
+            )
+            .fromTo(
+              listRef.current?.children ?? [],
+              { opacity: 0, y: 16 },
+              { opacity: 1, y: 0, duration: 0.4, stagger: 0.06 },
+              "-=0.3",
+            );
+        };
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            for (const entry of entries) {
+              if (entry.isIntersecting) {
+                trigger();
+                observer.disconnect();
+                break;
+              }
+            }
+          },
+          { threshold: 0.15 },
+        );
+        observer.observe(section);
+
+        return () => observer.disconnect();
+      });
+    }, sectionRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      id="faq"
+      className="relative z-10 px-6 py-24 max-w-3xl mx-auto w-full"
+    >
+      <div ref={headingRef} className="mb-10">
+        <p className="text-zinc-600 text-xs tracking-[0.3em] uppercase">
+          Frequently asked
+        </p>
+        <h2 className="text-white text-3xl md:text-4xl font-light tracking-tight mt-3">
+          Questions, answered.
+        </h2>
+      </div>
+
+      <div ref={listRef}>
+        {items.map((item, idx) => (
+          <FaqRow
+            key={item.question}
+            item={item}
+            open={openIndex === idx}
+            onToggle={() => setOpenIndex(openIndex === idx ? null : idx)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/shared/layout/landing/faq/index.ts
+++ b/src/shared/layout/landing/faq/index.ts
@@ -1,0 +1,1 @@
+export { Faq } from "./Faq";

--- a/src/shared/layout/landing/features-grid/FeaturesGrid.tsx
+++ b/src/shared/layout/landing/features-grid/FeaturesGrid.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  Code,
+  Feather,
+  HeartHandshake,
+  Lock,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react";
+import gsap from "gsap";
+
+import { Card, IconBox } from "@/shared/ui";
+
+type Feature = {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+};
+
+const features: Feature[] = [
+  {
+    icon: <Feather size={15} />,
+    title: "Markdown-native",
+    body: "Write the way you think — headings, lists, code, all from your keyboard.",
+  },
+  {
+    icon: <Sparkles size={15} />,
+    title: "AI assistant",
+    body: "Summarize, restructure, expand — every note has a built-in collaborator.",
+  },
+  {
+    icon: <RefreshCw size={15} />,
+    title: "Cloud sync",
+    body: "Edits land everywhere instantly. No merge dialogs, no plugin install.",
+  },
+  {
+    icon: <HeartHandshake size={15} />,
+    title: "Always free",
+    body: "Open product. No paywall, no usage caps, no upsell.",
+  },
+  {
+    icon: <Code size={15} />,
+    title: "Open source",
+    body: "Read the code, ship a PR, fork it if you want. The whole thing is yours.",
+  },
+  {
+    icon: <Lock size={15} />,
+    title: "Privacy-first",
+    body: "Your notes stay yours. No tracking, no resale, no surprises.",
+  },
+];
+
+export function FeaturesGrid() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const headingRef = useRef<HTMLDivElement>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+
+    const ctx = gsap.context(() => {
+      const mm = gsap.matchMedia();
+      mm.add("(prefers-reduced-motion: no-preference)", () => {
+        const trigger = () => {
+          gsap
+            .timeline({ defaults: { ease: "power3.out" } })
+            .fromTo(
+              headingRef.current,
+              { opacity: 0, y: 20 },
+              { opacity: 1, y: 0, duration: 0.6 },
+            )
+            .fromTo(
+              gridRef.current?.querySelectorAll("[data-feature]") ?? [],
+              { opacity: 0, y: 24, filter: "blur(4px)" },
+              {
+                opacity: 1,
+                y: 0,
+                filter: "blur(0px)",
+                duration: 0.55,
+                stagger: 0.05,
+              },
+              "-=0.3",
+            );
+        };
+
+        const observer = new IntersectionObserver(
+          (entries) => {
+            for (const entry of entries) {
+              if (entry.isIntersecting) {
+                trigger();
+                observer.disconnect();
+                break;
+              }
+            }
+          },
+          { threshold: 0.15 },
+        );
+        observer.observe(section);
+
+        return () => observer.disconnect();
+      });
+    }, sectionRef);
+
+    return () => ctx.revert();
+  }, []);
+
+  return (
+    <section
+      ref={sectionRef}
+      id="features"
+      className="relative z-10 px-6 py-24 max-w-6xl mx-auto w-full"
+    >
+      <div ref={headingRef} className="max-w-2xl mb-12">
+        <p className="text-zinc-600 text-xs tracking-[0.3em] uppercase">
+          Why Inkwell
+        </p>
+        <h2 className="text-white text-3xl md:text-4xl font-light tracking-tight mt-3">
+          A notes app you actually own.
+        </h2>
+        <p className="text-zinc-500 text-sm mt-3 leading-relaxed">
+          Every feature is built around one rule: your notes belong to you, and
+          the tool gets out of your way.
+        </p>
+      </div>
+
+      <div
+        ref={gridRef}
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+      >
+        {features.map((feature) => (
+          <Card
+            key={feature.title}
+            variant="default"
+            padding="lg"
+            data-feature
+          >
+            <div className="flex flex-col gap-4">
+              <IconBox icon={feature.icon} variant="default" size="sm" />
+              <div>
+                <h3 className="text-white text-sm font-medium tracking-tight">
+                  {feature.title}
+                </h3>
+                <p className="text-zinc-500 text-xs mt-1.5 leading-relaxed">
+                  {feature.body}
+                </p>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/shared/layout/landing/features-grid/index.ts
+++ b/src/shared/layout/landing/features-grid/index.ts
@@ -1,0 +1,1 @@
+export { FeaturesGrid } from "./FeaturesGrid";

--- a/src/shared/layout/landing/footer/Footer.tsx
+++ b/src/shared/layout/landing/footer/Footer.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { Code, Feather } from "lucide-react";
+
+type Column = {
+  heading: string;
+  links: { label: string; href: string; external?: boolean }[];
+};
+
+const columns: Column[] = [
+  {
+    heading: "Product",
+    links: [
+      { label: "Features", href: "#features" },
+      { label: "FAQ", href: "#faq" },
+      { label: "Sign up", href: "/register" },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { label: "GitHub", href: "https://github.com", external: true },
+      { label: "Changelog", href: "#" },
+    ],
+  },
+  {
+    heading: "Legal",
+    links: [
+      { label: "Privacy", href: "#" },
+      { label: "Terms", href: "#" },
+    ],
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="relative z-10 mt-16 border-t border-zinc-800/60 bg-zinc-950">
+      <div className="max-w-6xl mx-auto px-6 py-14">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
+          <div className="space-y-3 md:col-span-1">
+            <Link
+              href="/"
+              className="flex items-center gap-2 group w-fit"
+            >
+              <div className="w-7 h-7 rounded-lg bg-zinc-800 border border-zinc-700 flex items-center justify-center group-hover:border-zinc-500 transition-colors duration-300">
+                <Feather size={13} className="text-zinc-300" />
+              </div>
+              <span className="text-sm font-medium tracking-wide text-zinc-200">
+                inkwell
+              </span>
+            </Link>
+            <p className="text-zinc-600 text-xs leading-relaxed max-w-xs">
+              Open notes, for everyone. Built with care, free forever.
+            </p>
+          </div>
+
+          {columns.map((column) => (
+            <div key={column.heading} className="space-y-3">
+              <p className="text-zinc-700 text-[10px] tracking-[0.2em] uppercase">
+                {column.heading}
+              </p>
+              <ul className="space-y-2">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    {link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1.5 text-zinc-500 text-sm hover:text-zinc-200 transition-colors duration-200"
+                      >
+                        {link.label === "GitHub" && (
+                          <Code size={12} className="shrink-0" />
+                        )}
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link
+                        href={link.href}
+                        className="text-zinc-500 text-sm hover:text-zinc-200 transition-colors duration-200"
+                      >
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 pt-6 border-t border-zinc-800/60 flex flex-col sm:flex-row gap-3 items-start sm:items-center justify-between">
+          <p className="text-zinc-700 text-xs">
+            © {new Date().getFullYear()} Inkwell. Open and paywall-free.
+          </p>
+          <p className="text-zinc-700 text-xs">Crafted with care.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/shared/layout/landing/footer/index.ts
+++ b/src/shared/layout/landing/footer/index.ts
@@ -1,0 +1,1 @@
+export { Footer } from "./Footer";

--- a/src/shared/ui/dialog/Dialog.tsx
+++ b/src/shared/ui/dialog/Dialog.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import gsap from "gsap";
 import type { ReactNode } from "react";
 
 import { Button } from "@/shared/ui/button";
+import { usePortalMounted } from "@/shared/hooks/use-portal-mounted";
 
 export type DialogAction = {
   label: string;
@@ -45,6 +47,7 @@ export function Dialog({
 }: DialogProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const mounted = usePortalMounted();
 
   useEffect(() => {
     const overlay = overlayRef.current;
@@ -94,7 +97,9 @@ export function Dialog({
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <div
       ref={overlayRef}
       onClick={(e) => e.target === overlayRef.current && onClose()}
@@ -153,6 +158,7 @@ export function Dialog({
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/shared/ui/drawer/Drawer.tsx
+++ b/src/shared/ui/drawer/Drawer.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { X, Maximize2 } from "lucide-react";
 import gsap from "gsap";
 import type { ReactNode } from "react";
+
+import { usePortalMounted } from "@/shared/hooks/use-portal-mounted";
 
 type DrawerProps = {
   open: boolean;
@@ -32,6 +35,7 @@ export function Drawer({
 }: DrawerProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const mounted = usePortalMounted();
 
   useEffect(() => {
     const overlay = overlayRef.current;
@@ -72,7 +76,9 @@ export function Drawer({
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <div
       ref={overlayRef}
       onClick={(e) => e.target === overlayRef.current && onClose()}
@@ -117,6 +123,7 @@ export function Drawer({
 
         <div className="flex-1 overflow-y-auto">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/shared/ui/dropdown/Dropdown.tsx
+++ b/src/shared/ui/dropdown/Dropdown.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Check, ChevronDown } from "lucide-react";
 import gsap from "gsap";
 import type { ReactNode } from "react";
+
+import { usePortalMounted } from "@/shared/hooks/use-portal-mounted";
 
 export type DropdownItem = {
   id: string;
@@ -23,6 +26,8 @@ type DropdownProps = {
   width?: number;
 };
 
+type Coords = { top: number; left: number; width: number };
+
 export function Dropdown({
   trigger,
   items,
@@ -31,14 +36,23 @@ export function Dropdown({
   width = 200,
 }: DropdownProps) {
   const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<Coords>({ top: 0, left: 0, width });
   const menuRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const mounted = usePortalMounted();
 
   useEffect(() => {
     const menu = menuRef.current;
     if (!menu) return;
 
     if (open) {
+      const rect = containerRef.current!.getBoundingClientRect();
+      setCoords({
+        top: rect.bottom + 8,
+        left: align === "right" ? rect.right - width : rect.left,
+        width,
+      });
+      gsap.set(menu, { display: "block" });
       gsap.fromTo(
         menu,
         { opacity: 0, y: -6, scale: 0.97, filter: "blur(3px)" },
@@ -59,15 +73,18 @@ export function Dropdown({
         filter: "blur(3px)",
         duration: 0.15,
         ease: "power2.in",
+        onComplete: () => { gsap.set(menu, { display: "none" }); },
       });
     }
-  }, [open]);
+  }, [open, align, width]);
 
   useEffect(() => {
     const handleOutside = (e: MouseEvent) => {
       if (
         containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
+        !containerRef.current.contains(e.target as Node) &&
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node)
       ) {
         setOpen(false);
       }
@@ -82,47 +99,56 @@ export function Dropdown({
         {trigger}
       </div>
 
-      {open && (
-        <div
-          ref={menuRef}
-          style={{ width, [align === "right" ? "right" : "left"]: 0 }}
-          className="absolute top-full mt-2 bg-zinc-900 border border-zinc-800 rounded-2xl p-1.5 shadow-xl shadow-black/40 z-50"
-        >
-          {items.map((item) =>
-            item.separator ? (
-              <div key={item.id} className="my-1 h-px bg-zinc-800" />
-            ) : (
-              <button
-                key={item.id}
-                type="button"
-                disabled={item.disabled}
-                onClick={() => {
-                  if (!item.disabled) {
-                    onSelect?.(item.id);
-                    setOpen(false);
-                  }
-                }}
-                className={`
-                  w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-xs
-                  transition-all duration-150 cursor-pointer text-left
-                  disabled:opacity-40 disabled:cursor-not-allowed
-                  ${
-                    item.variant === "danger"
-                      ? "text-red-400 hover:bg-red-950/40 hover:text-red-300"
-                      : "text-zinc-400 hover:bg-zinc-800 hover:text-white"
-                  }
-                `}
-              >
-                {item.icon && <span className="shrink-0">{item.icon}</span>}
-                <span className="flex-1">{item.label}</span>
-                {item.checked && (
-                  <Check size={12} className="text-zinc-400 shrink-0" />
-                )}
-              </button>
-            ),
-          )}
-        </div>
-      )}
+      {mounted &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={{
+              display: "none",
+              position: "fixed",
+              top: coords.top,
+              left: coords.left,
+              width: coords.width,
+              zIndex: 9999,
+            }}
+            className="bg-zinc-900 border border-zinc-800 rounded-2xl p-1.5 shadow-xl shadow-black/40"
+          >
+            {items.map((item) =>
+              item.separator ? (
+                <div key={item.id} className="my-1 h-px bg-zinc-800" />
+              ) : (
+                <button
+                  key={item.id}
+                  type="button"
+                  disabled={item.disabled}
+                  onClick={() => {
+                    if (!item.disabled) {
+                      onSelect?.(item.id);
+                      setOpen(false);
+                    }
+                  }}
+                  className={`
+                    w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-xs
+                    transition-all duration-150 cursor-pointer text-left
+                    disabled:opacity-40 disabled:cursor-not-allowed
+                    ${
+                      item.variant === "danger"
+                        ? "text-red-400 hover:bg-red-950/40 hover:text-red-300"
+                        : "text-zinc-400 hover:bg-zinc-800 hover:text-white"
+                    }
+                  `}
+                >
+                  {item.icon && <span className="shrink-0">{item.icon}</span>}
+                  <span className="flex-1">{item.label}</span>
+                  {item.checked && (
+                    <Check size={12} className="text-zinc-400 shrink-0" />
+                  )}
+                </button>
+              ),
+            )}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/shared/ui/select/Select.tsx
+++ b/src/shared/ui/select/Select.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Check, ChevronDown } from "lucide-react";
 import gsap from "gsap";
+
+import { usePortalMounted } from "@/shared/hooks/use-portal-mounted";
 
 export type SelectOption = {
   value: string;
@@ -22,6 +25,8 @@ type SelectProps = {
   onChange?: (value: string) => void;
 };
 
+type Coords = { top: number; left: number; width: number };
+
 export function Select({
   options,
   value,
@@ -33,8 +38,11 @@ export function Select({
   onChange,
 }: SelectProps) {
   const [open, setOpen] = useState(false);
+  const [coords, setCoords] = useState<Coords>({ top: 0, left: 0, width: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const mounted = usePortalMounted();
   const hasError = !!error;
 
   const selected = options.find((o) => o.value === value);
@@ -44,6 +52,13 @@ export function Select({
     if (!menu) return;
 
     if (open) {
+      const rect = triggerRef.current!.getBoundingClientRect();
+      setCoords({
+        top: rect.bottom + 8,
+        left: rect.left,
+        width: rect.width,
+      });
+      gsap.set(menu, { display: "block" });
       gsap.fromTo(
         menu,
         { opacity: 0, y: -6, scale: 0.97, filter: "blur(3px)" },
@@ -64,6 +79,7 @@ export function Select({
         filter: "blur(3px)",
         duration: 0.15,
         ease: "power2.in",
+        onComplete: () => { gsap.set(menu, { display: "none" }); },
       });
     }
   }, [open]);
@@ -72,7 +88,9 @@ export function Select({
     const handleOutside = (e: MouseEvent) => {
       if (
         containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
+        !containerRef.current.contains(e.target as Node) &&
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node)
       ) {
         setOpen(false);
       }
@@ -91,6 +109,7 @@ export function Select({
 
       <div ref={containerRef} className="relative">
         <button
+          ref={triggerRef}
           type="button"
           disabled={disabled}
           onClick={() => !disabled && setOpen((v) => !v)}
@@ -125,42 +144,54 @@ export function Select({
           className={`absolute bottom-0 left-4 right-4 h-px bg-gradient-to-r from-transparent via-zinc-500 to-transparent transition-opacity duration-500 ${open && !hasError ? "opacity-100" : "opacity-0"}`}
         />
 
-        {open && (
-          <div
-            ref={menuRef}
-            className="absolute top-full left-0 right-0 mt-2 bg-zinc-900 border border-zinc-800 rounded-2xl p-1.5 shadow-xl shadow-black/40 z-50 max-h-56 overflow-y-auto"
-          >
-            {options.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                disabled={option.disabled}
-                onClick={() => {
-                  if (!option.disabled) {
-                    onChange?.(option.value);
-                    setOpen(false);
-                  }
-                }}
-                className={`
-                  w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm
-                  transition-all duration-150 cursor-pointer
-                  disabled:opacity-40 disabled:cursor-not-allowed
-                  ${
-                    option.value === value
-                      ? "bg-zinc-800 text-white"
-                      : "text-zinc-400 hover:bg-zinc-800/60 hover:text-white"
-                  }
-                `}
-              >
-                {option.icon && <span className="shrink-0">{option.icon}</span>}
-                <span className="flex-1 text-left">{option.label}</span>
-                {option.value === value && (
-                  <Check size={13} className="shrink-0 text-zinc-400" />
-                )}
-              </button>
-            ))}
-          </div>
-        )}
+        {mounted &&
+          createPortal(
+            <div
+              ref={menuRef}
+              style={{
+                display: "none",
+                position: "fixed",
+                top: coords.top,
+                left: coords.left,
+                width: coords.width,
+                zIndex: 9999,
+              }}
+              className="bg-zinc-900 border border-zinc-800 rounded-2xl p-1.5 shadow-xl shadow-black/40 max-h-56 overflow-y-auto"
+            >
+              {options.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  disabled={option.disabled}
+                  onClick={() => {
+                    if (!option.disabled) {
+                      onChange?.(option.value);
+                      setOpen(false);
+                    }
+                  }}
+                  className={`
+                    w-full flex items-center gap-2.5 px-3 py-2.5 rounded-xl text-sm
+                    transition-all duration-150 cursor-pointer
+                    disabled:opacity-40 disabled:cursor-not-allowed
+                    ${
+                      option.value === value
+                        ? "bg-zinc-800 text-white"
+                        : "text-zinc-400 hover:bg-zinc-800/60 hover:text-white"
+                    }
+                  `}
+                >
+                  {option.icon && (
+                    <span className="shrink-0">{option.icon}</span>
+                  )}
+                  <span className="flex-1 text-left">{option.label}</span>
+                  {option.value === value && (
+                    <Check size={13} className="shrink-0 text-zinc-400" />
+                  )}
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )}
       </div>
 
       {(error || hint) && (

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   X,
   CheckCircle2,
@@ -13,6 +14,7 @@ import gsap from "gsap";
 
 import { useToastStore } from "@/shared/stores/toast.store";
 import type { Toast, ToastVariant } from "@/shared/types/toast.types";
+import { usePortalMounted } from "@/shared/hooks/use-portal-mounted";
 
 const DEFAULT_DURATION = 4000;
 
@@ -156,12 +158,16 @@ function ToastItem({ toast }: { toast: Toast }) {
 
 export function Toast() {
   const toasts = useToastStore((s) => s.toasts);
+  const mounted = usePortalMounted();
 
-  return (
+  if (!mounted) return null;
+
+  return createPortal(
     <div className="fixed top-6 right-6 z-[200] flex flex-col gap-2.5 items-end">
       {toasts.map((t) => (
         <ToastItem key={t.id} toast={t} />
       ))}
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
# Fix: Portal-render all overlay components

Overlays (**Dialog, Drawer, Dropdown, Select, Toast**) were rendering inside the React component tree where they're declared. Any ancestor with `overflow: hidden`, a CSS `transform`, `filter`, or an explicit `z-index` creates a new stacking context that traps overlays below it — causing dialogs to appear clipped inside their parent card, drawers to slide in from inside a container, etc.

This PR moves every overlay to `document.body` via React's `createPortal`, making them immune to ancestor stacking contexts.

> **Note:** Tooltip was already portaled — no change needed.

---

## Changes

### `src/shared/hooks/use-portal-mounted.ts` (new)
A one-function SSR guard: returns `false` on the server, `true` after hydration. All portal components call it to avoid `document.body` access during static rendering.

### Dialog + Drawer
Single mechanical change:
1. Import `createPortal` + `usePortalMounted`.
2. Add an early `if (!mounted) return null`.
3. Wrap the existing JSX in `createPortal(…, document.body)`.

*Every GSAP ref, timeline, and Escape-key handler is untouched — refs still bind to the real DOM nodes, they just happen to live under `<body>`.*

### Toast
Same minimal change — the fixed `top-6 right-6` container is portaled to body. Individual `ToastItem` components with their GSAP slide/progress-bar timelines are unchanged.

### Dropdown + Select (moderate)
Two problems fixed simultaneously:

1. **Stacking context:** Menus portaled to body with `position: fixed` and coordinates calculated from the trigger's `getBoundingClientRect()` on each open.
2. **Broken GSAP close animation:** Both previously used `{open && <div ref={menuRef}>}`, mounting the menu on open and unmounting immediately on close. The GSAP close animation was targeting a node that no longer existed (silent failure). 

Fixed by switching to always-mounted with `display: none` managed by GSAP (same pattern already used by Dialog/Drawer):
* **Open:** `gsap.set(menu, { display: "block" })` → animate in
* **Close:** animate out → `onComplete: () => gsap.set(menu, { display: "none" })`

Outside-click detection updated to check both the trigger container and the portaled menu ref, so clicking inside the menu no longer closes it.